### PR TITLE
fix: correct environment variable name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before using the Binance Trade Bot, you need to configure your environment with 
 
    ```bash
    export BINANCE_API_KEY=<your-api-key>
-   export BINANCE_API_SECRET=<your-secret-key>
+   export BINANCE_SECRET_KEY=<your-secret-key>
    ```
 
 3. **Create a config file**


### PR DESCRIPTION
The documentation incorrectly referred to BINANCE_API_SECRET, while the code expects BINANCE_SECRET_KEY. Updated to ensure consistency.