### PR TITLE
Improve order safety and Binance filter validation

### DIFF
--- a/bulltrade.go
+++ b/bulltrade.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -26,231 +27,239 @@ func BullTrade(
 	sellFactor float64,
 	roundPrice uint,
 	roundAmount uint,
-	max_ops uint,
-) {
-
-	// read config.yml file
+	maxOps uint,
+) error {
 	var c config.Config
 	cfg, err := c.Read(configFile)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-	period := cfg.HistoricalPrices.Period     // length period for moving average
-	interval := cfg.HistoricalPrices.Interval // time intervals of historical prices for trading
+	period := cfg.HistoricalPrices.Period
+	interval := cfg.HistoricalPrices.Interval
 
-	// initialize binance api client
+	if err := validateBullTradeInputs(symbol, qty, stopLoss, takeProfit, buyFactor, sellFactor, maxOps); err != nil {
+		return err
+	}
+
 	client := binance_connector.NewClient(apikey, secretkey, baseurl)
+	ticker := strings.Replace(symbol, "/", "", -1)
+	rules, err := fetchSymbolRules(context.Background(), ticker)
+	if err != nil {
+		return fmt.Errorf("validating symbol rules for %s: %w", symbol, err)
+	}
+	if roundPrice < decimalPlacesFromStep(rules.TickSize, rules.QuotePrecision) {
+		log.Printf("round-price=%d is lower than Binance tick precision; using exchange tick size %.12f for validation", roundPrice, rules.TickSize)
+	}
+	if roundAmount < decimalPlacesFromStep(rules.StepSize, rules.BaseAssetPrecision) {
+		log.Printf("round-amount=%d is lower than Binance step precision; using exchange step size %.12f for validation", roundAmount, rules.StepSize)
+	}
 
-	// define text colors
 	cyan := color.New(color.FgHiCyan, color.Bold).SprintFunc()
 	red := color.New(color.FgHiRed, color.Bold).SprintFunc()
 	green := color.New(color.FgHiGreen, color.Bold).SprintFunc()
 	white := color.New(color.FgHiWhite, color.Bold).SprintFunc()
 
-	// validate symbol in format 0-9A-Z/0-9A-Z
-	if re := regexp.MustCompile(`(?m)^[0-9A-Z]{2,8}/[0-9A-Z]{2,8}$`); !re.Match([]byte(symbol)) {
-		log.Fatal("error parsing ticker: must match ^[0-9A-Z]{2,8}/[0-9A-Z]{2,8}$")
-	}
-	scoin, dcoin, found := strings.Cut(symbol, "/")
-	if !found {
-		log.Fatal("error parsing ticker: \"/\" is missing ")
-	}
-	ticker := strings.Replace(symbol, "/", "", -1)
+	scoin, dcoin, _ := strings.Cut(symbol, "/")
+	buyPrice := 0.0
+	operation := 1
 
-	var buyPrice float64
-	var operation = 1
-
-	for range max_ops {
-		// set tui writers
-		cpw := uilive.New() // current price line writer
+	for range maxOps {
+		cpw := uilive.New()
 		cpw.Start()
 
 		fmt.Println(white("Operation"), cyan("#"+strconv.Itoa(operation)))
 		qty = roundFloat(qty, roundAmount)
 
-		//// buy ////
 		for {
-			// get historical prices
 			hp, err := getHistoricalPrices(client, ticker, interval, period)
 			if err != nil {
 				log.Printf("Error getting historical prices with %s interval: %v\n", interval, err)
-				time.Sleep(10 * time.Second)
+				time.Sleep(defaultPollInterval)
+				continue
+			}
+			if len(hp) < 2 {
+				log.Printf("Not enough historical prices for %s: got %d\n", ticker, len(hp))
+				time.Sleep(defaultPollInterval)
 				continue
 			}
 
 			price := hp[len(hp)-1]
 			prevPrice := hp[len(hp)-2]
-
-			// print current price
 			printPrice(cpw, symbol, price, prevPrice, roundPrice)
 
-			// indicators
-			// tendency "up" or "down"
 			tendency, err := getTendency(client, ticker, cfg.Tendency.Interval, period)
 			if err != nil {
 				log.Printf("Error getting tendency: %v\n", err)
-				time.Sleep(10 * time.Second)
+				time.Sleep(defaultPollInterval)
 				continue
 			}
-			// dema
+
 			dema := calculateDEMA(hp, cfg.Indicators.Dema.Length)
-			currentDema := dema[len(dema)-1]
-			//rsi
 			rsi := calculateRSI(hp, cfg.Indicators.Rsi.Length)
-			// macd
-			macdLine, signalLine := calculateMACD(
-				hp,
-				cfg.Indicators.Macd.FastLength,
-				cfg.Indicators.Macd.SlowLength,
-				cfg.Indicators.Macd.SignalLength,
-			)
-			// bollingerbands
-			bb, err := CalculateBollingerBands(
-				hp,
-				cfg.Indicators.BollingerBands.Length,
-				cfg.Indicators.BollingerBands.Multiplier,
-			)
+			macdLine, signalLine := calculateMACD(hp, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
+			bb, err := CalculateBollingerBands(hp, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
 			if err != nil {
 				log.Printf("Error getting BollingerBands: %v\n", err)
+				time.Sleep(defaultPollInterval)
+				continue
 			}
+			if len(dema) == 0 || len(rsi) < 1 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 || len(bb.UpperBand) == 0 {
+				log.Printf("Indicators not ready yet for %s\n", ticker)
+				time.Sleep(defaultPollInterval)
+				continue
+			}
+
+			currentDema := dema[len(dema)-1]
 			lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
 			upperBand := bb.UpperBand[len(bb.UpperBand)-1]
 			distanceToUpper := math.Abs(currentDema - upperBand)
 			distanceToLower := math.Abs(currentDema - lowerBand)
 
-			// when to buy
-			if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) && // RSI below upper limit
+			if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) &&
 				macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
-				macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] && // MACD crosses signal
-				tendency == cfg.Tendency.Direction && // 3m tendency
-				distanceToLower < distanceToUpper { // dema closer than lower band
-				buy, err := TradeBuy(symbol, qty, price, buyFactor, roundPrice)
+				macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] &&
+				tendency == cfg.Tendency.Direction &&
+				distanceToLower < distanceToUpper {
+				buy, err := TradeBuy(context.Background(), symbol, qty, price, buyFactor, roundPrice)
 				if err != nil {
-					log.Fatalf("error creating BUY order: %s\n", err)
+					return fmt.Errorf("creating BUY order: %w", err)
 				}
 				buyOrder := reflect.ValueOf(buy).Elem()
-				orderId := buyOrder.FieldByName("OrderId").Int()
+				orderID := buyOrder.FieldByName("OrderId").Int()
 				orderPrice := buyOrder.FieldByName("Price").String()
 				buyPrice, err = strconv.ParseFloat(orderPrice, 64)
 				if err != nil {
-					log.Printf("could not convert price on buy order to float: %s\n", err)
+					return fmt.Errorf("could not convert buy order price to float: %w", err)
 				}
 
 				fmt.Printf("%s %s %f %s - PRICE: %s - Total %s: %f\n",
 					time.Now().Format("02/01/2006 15:04:05"), green("BUY"), qty, scoin, white(buyPrice), dcoin, buyPrice*qty)
 
-				if getor, err := GetOrder(ticker, orderId); err == nil {
+				if getor, err := GetOrder(context.Background(), ticker, orderID); err == nil {
 					fmt.Printf("%s BUY order created. Id: %d - Status: %s\n",
 						time.Now().Format("02/01/2006 15:04:05"), getor.OrderId, getor.Status)
 				}
 
-				for { // looking at buy order until is filled
-					if getor, err := GetOrder(ticker, orderId); err == nil {
-						if getor.Status == "FILLED" {
-							fmt.Printf("%s BUY order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"))
-							break // buy filled
-						}
-					}
-					time.Sleep(10 * time.Second) // 10 secs to take another look
+				if _, err := WaitForOrderFillOrCancel(context.Background(), ticker, orderID, defaultOrderFillWait); err != nil {
+					return fmt.Errorf("buy order %d was not filled safely: %w", orderID, err)
 				}
-				break // indicators conditions meet
+				fmt.Printf("%s BUY order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"))
+				break
 			}
 
-			time.Sleep(10 * time.Second)
+			time.Sleep(defaultPollInterval)
 		}
 		cpw.Stop()
-		time.Sleep(30 * time.Second) // sleep before start selling process
+		time.Sleep(30 * time.Second)
 
-		//// sell ////
 		cpw.Start()
 		for {
 			hp, err := getHistoricalPrices(client, ticker, interval, period)
 			if err != nil {
 				log.Printf("Error getting historical prices with %s interval: %v\n", interval, err)
-				time.Sleep(10 * time.Second)
+				time.Sleep(defaultPollInterval)
 				continue
 			}
 			rsiprices, err := getHistoricalPrices(client, ticker, cfg.Indicators.Rsi.Interval, period)
 			if err != nil {
 				log.Printf("Error getting historical prices with %s interval: %v\n", interval, err)
-				time.Sleep(10 * time.Second)
+				time.Sleep(defaultPollInterval)
+				continue
+			}
+			if len(hp) < 2 || len(rsiprices) == 0 {
+				log.Printf("Not enough sell-side data for %s\n", ticker)
+				time.Sleep(defaultPollInterval)
 				continue
 			}
 
 			price := hp[len(hp)-1]
 			prevPrice := hp[len(hp)-2]
 			rsi := calculateRSI(rsiprices, cfg.Indicators.Rsi.Length)
-
-			// print current price
-			printPrice(cpw, symbol, price, prevPrice, roundPrice)
-
-			// stop loss
-			stopLossPercentage := stopLoss
-			stopLossPrice := buyPrice * (1 - stopLossPercentage/100)
-			if price <= stopLossPrice { // price reach stop-loss percentage
-				sell, err := TradeSell(symbol, roundFloat(qty*0.998, roundAmount), price, 1.0, roundPrice)
-				if err != nil {
-					log.Fatalf("error creating Stop-Loss SELL order with amount %f: %s\n",
-						roundFloat(qty*0.998, roundAmount), err)
-				}
-				sellOrder := reflect.ValueOf(sell).Elem()
-				orderId := sellOrder.FieldByName("OrderId").Int()
-
-				fmt.Printf("%s %s %f %s - PRICE: %s - Total %s: %f\n",
-					time.Now().Format("02/01/2006 15:04:05"), red("SELL"), qty, scoin, white(price), dcoin, price*qty)
-
-				if getor, err := GetOrder(ticker, orderId); err == nil {
-					fmt.Printf("%s %s order created. Id: %d - Status: %s\n",
-						time.Now().Format("02/01/2006 15:04:05"), red("STOP-LOSS SELL"), getor.OrderId, getor.Status)
-				}
-				for { // looking at sell order until is filled
-					if getor, err := GetOrder(ticker, orderId); err == nil {
-						if getor.Status == "FILLED" {
-							fmt.Printf("%s %s order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"), red("STOP-LOSS SELL"))
-							break // sell filled
-						}
-					}
-					time.Sleep(10 * time.Second) // 10 secs to take another look
-				}
-				break // sold (stop loss)
+			if len(rsi) < 2 {
+				log.Printf("RSI not ready yet for %s\n", ticker)
+				time.Sleep(defaultPollInterval)
+				continue
 			}
 
-			// take profit
-			profitPercentage := takeProfit
-			profitPrice := buyPrice * (1 + profitPercentage/100)
-			if price >= profitPrice && // price reach take profit percentage
-				rsi[len(rsi)-1] < rsi[len(rsi)-2] { // and rsi turns down
-				sell, err := TradeSell(symbol, roundFloat(qty*0.998, roundAmount), price, sellFactor, roundPrice)
+			printPrice(cpw, symbol, price, prevPrice, roundPrice)
+
+			stopLossPrice := buyPrice * (1 - stopLoss/100)
+			if price <= stopLossPrice {
+				sell, err := TradeStopLossSell(context.Background(), symbol, roundFloat(qty*0.998, roundAmount))
 				if err != nil {
-					log.Fatalf("error creating SELL order with amount %f: %s\n",
-						roundFloat(qty*0.998, roundAmount), err)
+					return fmt.Errorf("creating stop-loss market sell for amount %f: %w", roundFloat(qty*0.998, roundAmount), err)
 				}
 				sellOrder := reflect.ValueOf(sell).Elem()
-				orderId := sellOrder.FieldByName("OrderId").Int()
+				orderID := sellOrder.FieldByName("OrderId").Int()
 
 				fmt.Printf("%s %s %f %s - PRICE: %s - Total %s: %f\n",
 					time.Now().Format("02/01/2006 15:04:05"), red("SELL"), qty, scoin, white(price), dcoin, price*qty)
 
-				if getor, err := GetOrder(ticker, orderId); err == nil {
+				if getor, err := GetOrder(context.Background(), ticker, orderID); err == nil {
+					fmt.Printf("%s %s order created. Id: %d - Status: %s\n",
+						time.Now().Format("02/01/2006 15:04:05"), red("STOP-LOSS MARKET SELL"), getor.OrderId, getor.Status)
+				}
+				if _, err := WaitForOrderFill(context.Background(), ticker, orderID, 30*time.Second); err != nil {
+					return fmt.Errorf("stop-loss market sell %d did not finish cleanly: %w", orderID, err)
+				}
+				fmt.Printf("%s %s order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"), red("STOP-LOSS MARKET SELL"))
+				break
+			}
+
+			profitPrice := buyPrice * (1 + takeProfit/100)
+			if price >= profitPrice && rsi[len(rsi)-1] < rsi[len(rsi)-2] {
+				sell, err := TradeSell(context.Background(), symbol, roundFloat(qty*0.998, roundAmount), price, sellFactor, roundPrice)
+				if err != nil {
+					return fmt.Errorf("creating SELL order with amount %f: %w", roundFloat(qty*0.998, roundAmount), err)
+				}
+				sellOrder := reflect.ValueOf(sell).Elem()
+				orderID := sellOrder.FieldByName("OrderId").Int()
+
+				fmt.Printf("%s %s %f %s - PRICE: %s - Total %s: %f\n",
+					time.Now().Format("02/01/2006 15:04:05"), red("SELL"), qty, scoin, white(price), dcoin, price*qty)
+
+				if getor, err := GetOrder(context.Background(), ticker, orderID); err == nil {
 					fmt.Printf("%s SELL order created. Id: %d - Status: %s\n",
 						time.Now().Format("02/01/2006 15:04:05"), getor.OrderId, getor.Status)
 				}
 
-				for { // looking at sell order until is filled
-					if getor, err := GetOrder(ticker, orderId); err == nil {
-						if getor.Status == "FILLED" {
-							fmt.Printf("%s SELL order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"))
-							break // sell filled
-						}
-					}
-					time.Sleep(10 * time.Second) // 10 secs to take another look
+				if _, err := WaitForOrderFillOrCancel(context.Background(), ticker, orderID, defaultOrderFillWait); err != nil {
+					return fmt.Errorf("sell order %d was not filled safely: %w", orderID, err)
 				}
-				break // sold
+				fmt.Printf("%s SELL order filled!\n\n", time.Now().Format("02/01/2006 15:04:05"))
+				break
 			}
-			time.Sleep(10 * time.Second)
+			time.Sleep(defaultPollInterval)
 		}
 		cpw.Stop()
 		operation++
-		time.Sleep(1 * time.Minute) // 1 minute to start next operation
+		time.Sleep(1 * time.Minute)
 	}
+
+	return nil
+}
+
+func validateBullTradeInputs(symbol string, qty, stopLoss, takeProfit, buyFactor, sellFactor float64, maxOps uint) error {
+	if re := regexp.MustCompile(`(?m)^[0-9A-Z]{2,8}/[0-9A-Z]{2,8}$`); !re.Match([]byte(symbol)) {
+		return fmt.Errorf("error parsing ticker: must match ^[0-9A-Z]{2,8}/[0-9A-Z]{2,8}$")
+	}
+	if qty <= 0 {
+		return fmt.Errorf("amount must be greater than zero")
+	}
+	if stopLoss <= 0 || stopLoss >= 100 {
+		return fmt.Errorf("stop-loss must be between 0 and 100")
+	}
+	if takeProfit <= 0 {
+		return fmt.Errorf("take-profit must be greater than zero")
+	}
+	if buyFactor <= 0 {
+		return fmt.Errorf("buy-factor must be greater than zero")
+	}
+	if sellFactor <= 0 {
+		return fmt.Errorf("sell-factor must be greater than zero")
+	}
+	if maxOps == 0 {
+		return fmt.Errorf("operations must be greater than zero")
+	}
+	return nil
 }

--- a/common.go
+++ b/common.go
@@ -2,12 +2,24 @@ package main
 
 import (
 	"math"
+	"strconv"
 )
 
 // Returns a float rounded by the given precision
 func roundFloat(val float64, precision uint) float64 {
 	ratio := math.Pow(10, float64(precision))
 	return math.Round(val*ratio) / ratio
+}
+
+func parseFloat(value string) float64 {
+	if value == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 // Implement a function to send alerts, for example, using a messaging service like Telegram or Slack.

--- a/exchange.go
+++ b/exchange.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultRequestTimeout = 15 * time.Second
+	defaultOrderFillWait  = 2 * time.Minute
+	defaultPollInterval   = 10 * time.Second
+)
+
+type SymbolRules struct {
+	Symbol             string
+	BaseAsset          string
+	QuoteAsset         string
+	BaseAssetPrecision uint
+	QuotePrecision     uint
+	TickSize           float64
+	StepSize           float64
+	MinQty             float64
+	MinNotional        float64
+}
+
+type exchangeInfoResponse struct {
+	Symbols []struct {
+		Symbol             string `json:"symbol"`
+		BaseAsset          string `json:"baseAsset"`
+		QuoteAsset         string `json:"quoteAsset"`
+		BaseAssetPrecision uint   `json:"baseAssetPrecision"`
+		QuotePrecision     uint   `json:"quotePrecision"`
+		Filters            []struct {
+			FilterType  string `json:"filterType"`
+			TickSize    string `json:"tickSize"`
+			StepSize    string `json:"stepSize"`
+			MinQty      string `json:"minQty"`
+			MinNotional string `json:"minNotional"`
+		} `json:"filters"`
+	} `json:"symbols"`
+}
+
+func fetchSymbolRules(ctx context.Context, symbol string) (SymbolRules, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+
+	url := fmt.Sprintf("%s/api/v3/exchangeInfo?symbol=%s", strings.TrimRight(baseurl, "/"), symbol)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return SymbolRules{}, fmt.Errorf("exchange info request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return SymbolRules{}, fmt.Errorf("exchange info fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return SymbolRules{}, fmt.Errorf("exchange info fetch: unexpected status %s", resp.Status)
+	}
+
+	var payload exchangeInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return SymbolRules{}, fmt.Errorf("exchange info decode: %w", err)
+	}
+	if len(payload.Symbols) != 1 {
+		return SymbolRules{}, fmt.Errorf("symbol %s not found on Binance", symbol)
+	}
+
+	raw := payload.Symbols[0]
+	rules := SymbolRules{
+		Symbol:             raw.Symbol,
+		BaseAsset:          raw.BaseAsset,
+		QuoteAsset:         raw.QuoteAsset,
+		BaseAssetPrecision: raw.BaseAssetPrecision,
+		QuotePrecision:     raw.QuotePrecision,
+	}
+
+	for _, filter := range raw.Filters {
+		switch filter.FilterType {
+		case "PRICE_FILTER":
+			rules.TickSize = parseFloat(filter.TickSize)
+		case "LOT_SIZE":
+			rules.StepSize = parseFloat(filter.StepSize)
+			rules.MinQty = parseFloat(filter.MinQty)
+		case "MIN_NOTIONAL", "NOTIONAL":
+			if rules.MinNotional == 0 {
+				rules.MinNotional = parseFloat(filter.MinNotional)
+			}
+		}
+	}
+
+	if rules.TickSize == 0 || rules.StepSize == 0 {
+		return SymbolRules{}, fmt.Errorf("symbol %s is missing required Binance filters", symbol)
+	}
+	return rules, nil
+}
+
+func floorToStep(value, step float64) float64 {
+	if step <= 0 {
+		return value
+	}
+	return math.Floor((value/step)+1e-9) * step
+}
+
+func decimalPlacesFromStep(step float64, fallback uint) uint {
+	if step <= 0 {
+		return fallback
+	}
+	for precision := uint(0); precision <= 12; precision++ {
+		scaled := step * math.Pow(10, float64(precision))
+		if math.Abs(scaled-math.Round(scaled)) < 1e-9 {
+			return precision
+		}
+	}
+	return fallback
+}
+
+func normalizeOrder(symbol string, quantity, price float64, rules SymbolRules) (float64, float64, error) {
+	adjQty := floorToStep(quantity, rules.StepSize)
+	adjPrice := floorToStep(price, rules.TickSize)
+	qtyPrecision := decimalPlacesFromStep(rules.StepSize, rules.BaseAssetPrecision)
+	pricePrecision := decimalPlacesFromStep(rules.TickSize, rules.QuotePrecision)
+	adjQty = roundFloat(adjQty, qtyPrecision)
+	adjPrice = roundFloat(adjPrice, pricePrecision)
+
+	if adjQty <= 0 {
+		return 0, 0, fmt.Errorf("%s quantity %.12f becomes invalid after applying step size %.12f", symbol, quantity, rules.StepSize)
+	}
+	if rules.MinQty > 0 && adjQty < rules.MinQty {
+		return 0, 0, fmt.Errorf("%s quantity %.12f is below Binance minimum %.12f", symbol, adjQty, rules.MinQty)
+	}
+	if adjPrice <= 0 {
+		return 0, 0, fmt.Errorf("%s price %.12f becomes invalid after applying tick size %.12f", symbol, price, rules.TickSize)
+	}
+	if rules.MinNotional > 0 && (adjQty*adjPrice) < rules.MinNotional {
+		return 0, 0, fmt.Errorf("%s notional %.12f is below Binance minimum %.12f", symbol, adjQty*adjPrice, rules.MinNotional)
+	}
+	return adjQty, adjPrice, nil
+}
+
+func normalizeMarketQuantity(symbol string, quantity float64, rules SymbolRules) (float64, error) {
+	adjQty := floorToStep(quantity, rules.StepSize)
+	qtyPrecision := decimalPlacesFromStep(rules.StepSize, rules.BaseAssetPrecision)
+	adjQty = roundFloat(adjQty, qtyPrecision)
+	if adjQty <= 0 {
+		return 0, fmt.Errorf("%s quantity %.12f becomes invalid after applying step size %.12f", symbol, quantity, rules.StepSize)
+	}
+	if rules.MinQty > 0 && adjQty < rules.MinQty {
+		return 0, fmt.Errorf("%s quantity %.12f is below Binance minimum %.12f", symbol, adjQty, rules.MinQty)
+	}
+	return adjQty, nil
+}

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+func TestNormalizeOrderUsesExchangeFilters(t *testing.T) {
+	rules := SymbolRules{
+		Symbol:             "BTCUSDT",
+		BaseAssetPrecision: 6,
+		QuotePrecision:     2,
+		TickSize:           0.10,
+		StepSize:           0.001,
+		MinQty:             0.001,
+		MinNotional:        10,
+	}
+
+	qty, price, err := normalizeOrder("BTCUSDT", 0.123456, 43123.987, rules)
+	if err != nil {
+		t.Fatalf("normalizeOrder returned unexpected error: %v", err)
+	}
+	if qty != 0.123 {
+		t.Fatalf("expected qty 0.123, got %f", qty)
+	}
+	if price != 43123.90 {
+		t.Fatalf("expected price 43123.90, got %f", price)
+	}
+}
+
+func TestNormalizeOrderRejectsBelowMinNotional(t *testing.T) {
+	rules := SymbolRules{
+		Symbol:      "ADAUSDT",
+		TickSize:    0.0001,
+		StepSize:    0.1,
+		MinQty:      0.1,
+		MinNotional: 10,
+	}
+
+	_, _, err := normalizeOrder("ADAUSDT", 5, 1.5, rules)
+	if err == nil {
+		t.Fatal("expected min notional validation error")
+	}
+}
+
+func TestValidateBullTradeInputs(t *testing.T) {
+	if err := validateBullTradeInputs("BTC/USDT", 10, 3, 2.5, 0.9999, 1.0001, 1); err != nil {
+		t.Fatalf("expected valid inputs, got error: %v", err)
+	}
+	if err := validateBullTradeInputs("BTCUSDT", 10, 3, 2.5, 0.9999, 1.0001, 1); err == nil {
+		t.Fatal("expected invalid ticker error")
+	}
+	if err := validateBullTradeInputs("BTC/USDT", 0, 3, 2.5, 0.9999, 1.0001, 1); err == nil {
+		t.Fatal("expected invalid amount error")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -103,10 +103,9 @@ func main() {
 					},
 				},
 				Action: func(cCtx *cli.Context) error {
-					BullTrade(cCtx.String("config-file"), cCtx.String("ticker"), cCtx.Float64("amount"), cCtx.Float64("stop-loss"), cCtx.Float64("take-profit"),
+					return BullTrade(cCtx.String("config-file"), cCtx.String("ticker"), cCtx.Float64("amount"), cCtx.Float64("stop-loss"), cCtx.Float64("take-profit"),
 						cCtx.Float64("buy-factor"), cCtx.Float64("sell-factor"), cCtx.Uint("round-price"), cCtx.Uint("round-amount"),
 						cCtx.Uint("operations"))
-					return nil
 				},
 			},
 		},

--- a/order.go
+++ b/order.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	binance "github.com/binance/binance-connector-go"
 )
@@ -11,9 +12,9 @@ import (
 
 func GetAllOrders(symbol string) {
 	client := binance.NewClient(apikey, secretkey, baseurl)
-	// Binance Get all account orders; active, canceled, or filled - GET /api/v3/allOrders
-	getAllOrders, err := client.NewGetAllOrdersService().Symbol(symbol).
-		Do(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
+	defer cancel()
+	getAllOrders, err := client.NewGetAllOrdersService().Symbol(symbol).Do(ctx)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -21,41 +22,103 @@ func GetAllOrders(symbol string) {
 	fmt.Println(binance.PrettyPrint(getAllOrders))
 }
 
-func GetOrder(symbol string, id int64) (res *binance.GetOrderResponse, err error) {
+func GetOrder(ctx context.Context, symbol string, id int64) (res *binance.GetOrderResponse, err error) {
 	client := binance.NewClient(apikey, secretkey, baseurl)
-	order, err := client.NewGetOrderService().Symbol(symbol).OrderId(id).Do(context.Background())
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+	order, err := client.NewGetOrderService().Symbol(symbol).OrderId(id).Do(ctx)
 	if err != nil {
 		return &binance.GetOrderResponse{}, err
 	}
 	return order, nil
 }
 
-func NewOrder(symbol, side string, quantity, price float64) (interface{}, error) {
-
+func CancelOrder(ctx context.Context, symbol string, id int64) error {
 	client := binance.NewClient(apikey, secretkey, baseurl)
-
-	newOrder, err := client.NewCreateOrderService().Symbol(symbol).Side(side).
-		Type("LIMIT").TimeInForce("GTC").Quantity(quantity).Price(price).Do(context.Background())
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+	_, err := client.NewCancelOrderService().Symbol(symbol).OrderId(id).Do(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("order: creating new order: %w", err)
+		return fmt.Errorf("cancel order %d for %s: %w", id, symbol, err)
 	}
-	return newOrder, nil
-
+	return nil
 }
 
-// TODO set stop loss boundaries
-/* func placeStopLossOrder(client *binance.Client, symbol string, quantity, stopPrice, limitPrice float64) error {
-	order, err := client.NewCreateOrderService().
-		Symbol(symbol).
-		Side(binance.SideTypeSell).
-		Type(binance.OrderTypeStopLossLimit).
-		Quantity(fmt.Sprintf("%f", quantity)).
-		StopPrice(fmt.Sprintf("%f", stopPrice)).
-		Price(fmt.Sprintf("%f", limitPrice)).
-		Do(context.Background())
+func NewOrder(ctx context.Context, symbol, side string, quantity, price float64) (interface{}, error) {
+	rules, err := fetchSymbolRules(ctx, symbol)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	log.Printf("Orden de stop-loss creada: %v", order)
-	return nil
-} */
+	adjQty, adjPrice, err := normalizeOrder(symbol, quantity, price, rules)
+	if err != nil {
+		return nil, err
+	}
+
+	client := binance.NewClient(apikey, secretkey, baseurl)
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+
+	newOrder, err := client.NewCreateOrderService().Symbol(symbol).Side(side).
+		Type("LIMIT").TimeInForce("GTC").Quantity(adjQty).Price(adjPrice).Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("order: creating new %s limit order on %s with qty %.12f and price %.12f: %w", side, symbol, adjQty, adjPrice, err)
+	}
+	return newOrder, nil
+}
+
+func NewMarketOrder(ctx context.Context, symbol, side string, quantity float64) (interface{}, error) {
+	rules, err := fetchSymbolRules(ctx, symbol)
+	if err != nil {
+		return nil, err
+	}
+	adjQty, err := normalizeMarketQuantity(symbol, quantity, rules)
+	if err != nil {
+		return nil, err
+	}
+
+	client := binance.NewClient(apikey, secretkey, baseurl)
+	ctx, cancel := context.WithTimeout(ctx, defaultRequestTimeout)
+	defer cancel()
+
+	newOrder, err := client.NewCreateOrderService().Symbol(symbol).Side(side).
+		Type("MARKET").Quantity(adjQty).Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("order: creating new %s market order on %s with qty %.12f: %w", side, symbol, adjQty, err)
+	}
+	return newOrder, nil
+}
+
+func WaitForOrderFill(ctx context.Context, symbol string, orderID int64, timeout time.Duration) (*binance.GetOrderResponse, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		order, err := GetOrder(waitCtx, symbol, orderID)
+		if err == nil {
+			switch order.Status {
+			case "FILLED":
+				return order, nil
+			case "CANCELED", "EXPIRED", "REJECTED":
+				return order, fmt.Errorf("order %d ended with status %s", orderID, order.Status)
+			}
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return nil, fmt.Errorf("timed out waiting for order %d fill: %w", orderID, waitCtx.Err())
+		case <-time.After(defaultPollInterval):
+		}
+	}
+}
+
+func WaitForOrderFillOrCancel(ctx context.Context, symbol string, orderID int64, timeout time.Duration) (*binance.GetOrderResponse, error) {
+	order, err := WaitForOrderFill(ctx, symbol, orderID, timeout)
+	if err == nil {
+		return order, nil
+	}
+	cancelErr := CancelOrder(context.Background(), symbol, orderID)
+	if cancelErr != nil {
+		return nil, fmt.Errorf("%v; additionally failed to cancel order: %w", err, cancelErr)
+	}
+	return nil, fmt.Errorf("%v; order cancellation requested", err)
+}

--- a/trade.go
+++ b/trade.go
@@ -1,23 +1,33 @@
 package main
 
 import (
+	"context"
 	"strings"
 )
 
-func TradeBuy(ticker string, qty, basePrice, buyFactor float64, round uint) (any, error) {
+func TradeBuy(ctx context.Context, ticker string, qty, basePrice, buyFactor float64, round uint) (any, error) {
 	buyPrice := roundFloat(basePrice*buyFactor, round)
 	tick := strings.Replace(ticker, "/", "", -1)
-	order, err := NewOrder(tick, "BUY", qty, buyPrice)
+	order, err := NewOrder(ctx, tick, "BUY", qty, buyPrice)
 	if err != nil {
 		return nil, err
 	}
 	return order, nil
 }
 
-func TradeSell(ticker string, qty, basePrice, sellFactor float64, round uint) (any, error) {
+func TradeSell(ctx context.Context, ticker string, qty, basePrice, sellFactor float64, round uint) (any, error) {
 	sellPrice := roundFloat(basePrice*sellFactor, round)
 	tick := strings.Replace(ticker, "/", "", -1)
-	order, err := NewOrder(tick, "SELL", qty, sellPrice)
+	order, err := NewOrder(ctx, tick, "SELL", qty, sellPrice)
+	if err != nil {
+		return nil, err
+	}
+	return order, nil
+}
+
+func TradeStopLossSell(ctx context.Context, ticker string, qty float64) (any, error) {
+	tick := strings.Replace(ticker, "/", "", -1)
+	order, err := NewMarketOrder(ctx, tick, "SELL", qty)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- validate and normalize order price/quantity using Binance exchange filters
- add request timeouts, order wait timeouts, and cancel stale limit orders
- switch stop-loss exit to market sell for more reliable execution during fast drops
- improve input validation and indicator safety checks
- add tests for exchange normalization and validation

## Validation
- gofmt
- go test ./...
- go build ./...