### PR TITLE
feat: Configurable Binance API Base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.7.0
+     v0.8.0
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -248,6 +248,21 @@ While the bot is running, the following keys are available inside the TUI:
 ## Configuration
 
 The bot is configured through a YAML file. See [sample-binance-config.yml](/sample-binance-config.yml) for a complete example.
+
+### Base URL Configuration
+
+You can override the Binance API base URL to use alternative endpoints such as the testnet:
+
+```yaml
+base-url: "https://testnet.binance.vision"
+```
+
+If omitted or empty, the default `https://api1.binance.com` (production) is used.
+
+| Environment | URL |
+|-------------|-----|
+| Production (default) | `https://api1.binance.com` |
+| Testnet | `https://testnet.binance.vision` |
 
 ### Indicators Configuration
 

--- a/config/README.md
+++ b/config/README.md
@@ -4,6 +4,7 @@ This document describes every parameter available in the YAML configuration file
 
 ## Table of Contents
 
+- [Base URL](#base-url)
 - [Historical Prices](#historical-prices)
 - [Refresh Interval](#refresh-interval)
 - [Tendency](#tendency)
@@ -23,6 +24,25 @@ This document describes every parameter available in the YAML configuration file
   - [Scalping (High-Frequency)](#scalping-high-frequency)
   - [Mid-Term Trading (Swing)](#mid-term-trading-swing)
   - [Long-Term Trading (Position)](#long-term-trading-position)
+
+---
+
+## Base URL
+
+Overrides the Binance API base URL. Useful for switching between production and testnet environments.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `base-url` | string | `"https://api1.binance.com"` | Binance API base URL. If omitted or empty, the default production URL is used. |
+
+| Environment | URL |
+|-------------|-----|
+| Production (default) | `https://api1.binance.com` |
+| Testnet | `https://testnet.binance.vision` |
+
+```yaml
+base-url: "https://testnet.binance.vision"
+```
 
 ---
 

--- a/config/file.go
+++ b/config/file.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Config struct {
+	BaseURL string `yaml:"base-url"`
 	HistoricalPrices struct {
 		Period   int    `yaml:"period"`
 		Interval string `yaml:"interval"`

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.7.5",
+		Version:  "v0.8.0",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -1,4 +1,9 @@
 # Sample config.yml file
+
+# Binance API base URL (default: https://api1.binance.com)
+# Use https://testnet.binance.vision for testnet
+base-url: "https://api1.binance.com"
+
 historical-prices:
   period: 100
   interval: "1m"

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -4,6 +4,10 @@
 # CLI example:
 #   binance-bot bt -t PEPE/USDT -a 50 --sl 1.0 --tp 0.5 -b 0.9999 -s 1.0001 -rp 8 -ra 0 -o 500 -f scalp-config.yml
 
+# Binance API base URL (default: https://api1.binance.com)
+# Use https://testnet.binance.vision for testnet
+base-url: "https://api1.binance.com"
+
 historical-prices:
   period: 50            # shorter lookback → faster indicator response
   interval: "1m"        # 1-minute candles for rapid signals

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -40,6 +40,9 @@ func BearTrade(
 	if err != nil {
 		log.Fatal(err)
 	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
 	period := cfg.HistoricalPrices.Period
 	interval := cfg.HistoricalPrices.Interval
 

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -39,6 +39,9 @@ func BullTrade(
 	if err != nil {
 		log.Fatal(err)
 	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
 	period := cfg.HistoricalPrices.Period     // length period for moving average
 	interval := cfg.HistoricalPrices.Interval // time intervals of historical prices for trading
 

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -42,6 +42,9 @@ func DynamicTrade(
 	if err != nil {
 		log.Fatal(err)
 	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
 	period := cfg.HistoricalPrices.Period
 	interval := cfg.HistoricalPrices.Interval
 

--- a/strategy/topgainers.go
+++ b/strategy/topgainers.go
@@ -43,6 +43,9 @@ func TopGainers(configFile string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
 
 	quoteAsset := cfg.TopGainers.QuoteAsset
 	if quoteAsset == "" {


### PR DESCRIPTION
## Configurable Binance API Base URL

### Summary

Adds a `base-url` configuration option to the YAML config file, allowing users to point the bot at alternative Binance API endpoints (e.g., the testnet at `https://testnet.binance.vision`).

### Motivation

- Users needed a way to test the bot against Binance's testnet without modifying source code.
- Hardcoding the production URL made it impossible to switch environments via configuration alone.

### Changes

| File | Change |
|------|--------|
| `config/file.go` | Added `BaseURL` field (`base-url` YAML key) to the `Config` struct |
| `exchange/client.go` | No change — `BaseURL` package variable remains the default (`https://api1.binance.com`) |
| `strategy/bull.go` | Override `exchange.BaseURL` from config if `base-url` is set |
| `strategy/bear.go` | Override `exchange.BaseURL` from config if `base-url` is set |
| `strategy/dynamic.go` | Override `exchange.BaseURL` from config if `base-url` is set |
| `strategy/topgainers.go` | Override `exchange.BaseURL` from config if `base-url` is set |
| `sample-binance-config.yml` | Added `base-url` option with comment documenting testnet URL |
| `sample-scalp-config.yml` | Added `base-url` option with comment documenting testnet URL |
| `main.go` | Version bumped `v0.7.5` → `v0.8.0` |
| `README.md` | Added "Base URL Configuration" section, updated version in help output |

### Usage

```yaml
# Use Binance testnet
base-url: "https://testnet.binance.vision"
```

If `base-url` is omitted or empty, the default production URL (`https://api1.binance.com`) is used.

**Configuration Popup (`c` key):**
- Displays all loaded YAML config values organized by section
- Closes with `c` or `Esc`

### Testing

- `go build ./...` — compiles successfully
- `go test -v ./...` — all existing tests pass
- No behavioral changes to trading logic; defaults remain unchanged

### Version

`v0.7.5` → `v0.8.0` (minor: new configuration feature)