### PR TITLE
feat: hardening and unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **Bear Trade** — Sell-high-buy-low strategy for downtrending markets
 - **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system; no longer requires all signals simultaneously
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
-- **AI Multi-Agent System** — Concurrent analysis from OpenAI, DeepSeek, and Claude with weighted consensus; acts as a mandatory approval gate for trade entries and take-profit exits
+- **AI Multi-Agent System** — Concurrent analysis from OpenAI, DeepSeek, and Claude with weighted consensus; when enabled, entries require explicit AI approval at the configured confidence threshold
 - **Sentiment Analysis** — Real-time news headlines and Fear & Greed Index integrated into AI decisions
 - **Trailing Stop-Loss** — Dynamically locks in profits as price moves favorably
 - **Advanced Indicators** — RSI, MACD, DEMA, Bollinger Bands, ADX, ATR, and volume confirmation
@@ -145,7 +145,7 @@ binance-bot -f sample-scalp-config.yml bull-trade -t "PEPE/USDT" -a 50 --sl 0.6 
 This example:
 - Uses 1-minute candles and a scoring-based entry (any 3 of 6 signals bullish).
 - Sets tight stop-loss / take-profit suitable for volatile low-cap tokens.
-- Runs up to 500 operations with only 5s between them for maximum trade frequency.
+- Runs up to 500 operations with only 10s between completed operations.
 - See [sample-scalp-config.yml](/sample-scalp-config.yml) for the full config.
 
 #### Top Gainers Monitor
@@ -194,7 +194,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.8.0
+     v0.8.1
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -390,7 +390,7 @@ ai:
 - **CryptoCompare** — latest news headlines for the traded coin
 - **Alternative.me Fear & Greed Index** — overall crypto market mood
 
-> Set `ai.enabled: false` or omit all provider API keys to disable AI and run on technical indicators only.
+> Set `ai.enabled: false` or omit all provider API keys to disable AI and run on technical indicators only. This is recommended for low-latency scalp configurations unless you intentionally want slower AI-gated entries.
 
 ### File Logging
 
@@ -438,7 +438,7 @@ In **classic mode**, the bot places a buy order when **all** of the following co
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
 6. **Volume Confirmation** *(if configured)*: Current volume exceeds its moving average, avoiding false breakouts.
-7. **AI Consensus** *(if enabled)*: The multi-agent system approves the entry or does not contradict it.
+7. **AI Consensus** *(if enabled)*: The multi-agent system must explicitly approve the entry at or above `ai.min-confidence`.
 
 #### **Sell Conditions**
 The bot will exit a position through one of three mechanisms:
@@ -465,7 +465,7 @@ The bot will open a short position (sell) when:
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Upper Band than the Lower Band, suggesting a potential reversal from overbought conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX confirms the trend has strength.
 6. **Volume Confirmation** *(if configured)*: Current volume exceeds its moving average.
-7. **AI Consensus** *(if enabled)*: The multi-agent system approves the entry.
+7. **AI Consensus** *(if enabled)*: The multi-agent system must explicitly approve the entry at or above `ai.min-confidence`.
 
 #### **Buy-Back Exit Conditions**
 The bot will exit the bear position (buy back) through one of three mechanisms:
@@ -516,9 +516,9 @@ Sentiment Data ────────┘       │         │         │
                           OpenAI    DeepSeek    Claude
 ```
 
-- **Entry signals**: Technical conditions must pass first, then AI must approve (or at least HOLD). If AI returns a contradicting signal with ≥50% confidence, the trade is **blocked** regardless of how many technical indicators are favorable.
+- **Entry signals**: Technical conditions must pass first, then AI must explicitly approve with the matching signal (`BUY` for bull entry, `SELL` for bear entry) at or above `ai.min-confidence`. `HOLD`, low-confidence, malformed, or opposing AI output blocks new exposure.
 - **Stop-loss / trailing-stop exits**: Execute **immediately** without waiting for AI — safety first.
-- **Take-profit exits**: Require AI confirmation to avoid exiting too early in strong trends.
+- **Take-profit exits**: AI is allowed to block the exit only when it gives a confident opposite signal. `HOLD` and low-confidence output do not prevent taking profit once the technical exit checks pass.
 
 > [!NOTE]
 > The AI consensus is considered alongside — not instead of — the technical indicators. Both must agree for a trade to execute. This dual-confirmation approach reduces false signals while preserving protective exits.

--- a/ai/agent.go
+++ b/ai/agent.go
@@ -14,9 +14,9 @@ import (
 type Signal string
 
 const (
-	SignalBuy    Signal = "BUY"
-	SignalSell   Signal = "SELL"
-	SignalHold   Signal = "HOLD"
+	SignalBuy     Signal = "BUY"
+	SignalSell    Signal = "SELL"
+	SignalHold    Signal = "HOLD"
 	SignalUnknown Signal = "UNKNOWN"
 )
 
@@ -31,32 +31,32 @@ type AgentDecision struct {
 
 // ConsensusResult aggregates decisions from all agents
 type ConsensusResult struct {
-	FinalSignal    Signal
-	BuyScore       float64
-	SellScore      float64
-	HoldScore      float64
-	AvgConfidence  float64
-	Decisions      []AgentDecision
-	SentimentData  *SentimentData
+	FinalSignal   Signal
+	BuyScore      float64
+	SellScore     float64
+	HoldScore     float64
+	AvgConfidence float64
+	Decisions     []AgentDecision
+	SentimentData *SentimentData
 }
 
 // TechnicalSnapshot contains the current state of all technical indicators
 type TechnicalSnapshot struct {
-	Symbol        string
-	Price         float64
-	PrevPrice     float64
-	RSI           float64
-	MACDLine      float64
+	Symbol         string
+	Price          float64
+	PrevPrice      float64
+	RSI            float64
+	MACDLine       float64
 	SignalLine     float64
-	PrevMACDLine  float64
+	PrevMACDLine   float64
 	PrevSignalLine float64
-	UpperBand     float64
-	LowerBand     float64
-	DEMA          float64
-	Tendency      string
-	ADX           float64
-	Volume        float64
-	AvgVolume     float64
+	UpperBand      float64
+	LowerBand      float64
+	DEMA           float64
+	Tendency       string
+	ADX            float64
+	Volume         float64
+	AvgVolume      float64
 }
 
 // FormatForPrompt returns technical data formatted for LLM consumption
@@ -99,9 +99,9 @@ func describeMACDCross(prevMACD, prevSignal, curMACD, curSignal float64) string 
 
 // Orchestrator manages multiple AI agents and produces consensus decisions
 type Orchestrator struct {
-	clients  []*LLMClient
-	cacheTTL time.Duration
-	mu       sync.Mutex
+	clients       []*LLMClient
+	cacheTTL      time.Duration
+	mu            sync.Mutex
 	lastSentiment *SentimentData
 	lastFetch     time.Time
 }
@@ -253,13 +253,18 @@ func parseAgentResponse(content, agentName string, provider Provider) AgentDecis
 		upper := strings.ToUpper(line)
 
 		if strings.HasPrefix(upper, "SIGNAL:") {
-			sigStr := strings.TrimSpace(strings.TrimPrefix(upper, "SIGNAL:"))
-			switch {
-			case strings.Contains(sigStr, "BUY"):
+			sigStr := strings.Trim(strings.TrimSpace(strings.TrimPrefix(upper, "SIGNAL:")), ".;,:")
+			if fields := strings.Fields(sigStr); len(fields) == 1 {
+				sigStr = strings.Trim(fields[0], ".;,:")
+			} else {
+				sigStr = ""
+			}
+			switch sigStr {
+			case "BUY":
 				d.Signal = SignalBuy
-			case strings.Contains(sigStr, "SELL"):
+			case "SELL":
 				d.Signal = SignalSell
-			case strings.Contains(sigStr, "HOLD"):
+			case "HOLD":
 				d.Signal = SignalHold
 			}
 		}
@@ -334,12 +339,41 @@ func buildConsensus(decisions []AgentDecision, sentiment *SentimentData) *Consen
 
 // ShouldBuy returns true if AI consensus supports buying
 func (cr *ConsensusResult) ShouldBuy() bool {
-	return cr.FinalSignal == SignalBuy && cr.AvgConfidence >= 0.5
+	return cr.ShouldBuyWithMinConfidence(0.5)
 }
 
 // ShouldSell returns true if AI consensus supports selling
 func (cr *ConsensusResult) ShouldSell() bool {
-	return cr.FinalSignal == SignalSell && cr.AvgConfidence >= 0.5
+	return cr.ShouldSellWithMinConfidence(0.5)
+}
+
+// ShouldBuyWithMinConfidence returns true if AI consensus explicitly supports buying
+// at or above the configured confidence threshold.
+func (cr *ConsensusResult) ShouldBuyWithMinConfidence(minConfidence float64) bool {
+	return cr.FinalSignal == SignalBuy && cr.AvgConfidence >= normalizedMinConfidence(minConfidence)
+}
+
+// ShouldSellWithMinConfidence returns true if AI consensus explicitly supports selling
+// at or above the configured confidence threshold.
+func (cr *ConsensusResult) ShouldSellWithMinConfidence(minConfidence float64) bool {
+	return cr.FinalSignal == SignalSell && cr.AvgConfidence >= normalizedMinConfidence(minConfidence)
+}
+
+// AllowsExit returns true unless AI gives a confident signal against the requested
+// exit action. This prevents low-confidence AI output from blocking profit-taking.
+func (cr *ConsensusResult) AllowsExit(exitSignal Signal, minConfidence float64) bool {
+	minConfidence = normalizedMinConfidence(minConfidence)
+	if cr.AvgConfidence < minConfidence {
+		return true
+	}
+	return cr.FinalSignal == exitSignal || cr.FinalSignal == SignalHold
+}
+
+func normalizedMinConfidence(minConfidence float64) float64 {
+	if minConfidence <= 0 || minConfidence > 1 {
+		return 0.5
+	}
+	return minConfidence
 }
 
 // String returns a human-readable summary

--- a/ai/agent_test.go
+++ b/ai/agent_test.go
@@ -1,0 +1,97 @@
+package ai
+
+import "testing"
+
+func TestParseAgentResponseRequiresExactSignal(t *testing.T) {
+	decision := parseAgentResponse(`SIGNAL: BUY OR HOLD
+CONFIDENCE: 0.9
+REASONING: ambiguous`, "test-agent", ProviderOpenAI)
+
+	if decision.Signal != SignalHold {
+		t.Fatalf("expected ambiguous signal to default to HOLD, got %s", decision.Signal)
+	}
+}
+
+func TestParseAgentResponseParsesStructuredFields(t *testing.T) {
+	decision := parseAgentResponse(`SIGNAL: SELL.
+CONFIDENCE: 0.72
+REASONING: bearish crossover with weak volume`, "test-agent", ProviderDeepSeek)
+
+	if decision.Signal != SignalSell {
+		t.Fatalf("expected SELL, got %s", decision.Signal)
+	}
+	if decision.Confidence != 0.72 {
+		t.Fatalf("expected confidence 0.72, got %f", decision.Confidence)
+	}
+	if decision.Reasoning != "bearish crossover with weak volume" {
+		t.Fatalf("unexpected reasoning: %q", decision.Reasoning)
+	}
+}
+
+func TestConsensusMinConfidence(t *testing.T) {
+	result := &ConsensusResult{
+		FinalSignal:   SignalBuy,
+		AvgConfidence: 0.64,
+	}
+
+	if !result.ShouldBuyWithMinConfidence(0.6) {
+		t.Fatal("expected BUY to pass configured confidence threshold")
+	}
+	if result.ShouldBuyWithMinConfidence(0.7) {
+		t.Fatal("expected BUY to fail higher configured confidence threshold")
+	}
+}
+
+func TestConsensusAllowsExit(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      ConsensusResult
+		exitSignal  Signal
+		wantAllowed bool
+	}{
+		{
+			name: "low-confidence opposite signal does not block profit exit",
+			result: ConsensusResult{
+				FinalSignal:   SignalBuy,
+				AvgConfidence: 0.4,
+			},
+			exitSignal:  SignalSell,
+			wantAllowed: true,
+		},
+		{
+			name: "hold allows profit exit",
+			result: ConsensusResult{
+				FinalSignal:   SignalHold,
+				AvgConfidence: 0.9,
+			},
+			exitSignal:  SignalSell,
+			wantAllowed: true,
+		},
+		{
+			name: "confident opposite signal blocks profit exit",
+			result: ConsensusResult{
+				FinalSignal:   SignalBuy,
+				AvgConfidence: 0.8,
+			},
+			exitSignal:  SignalSell,
+			wantAllowed: false,
+		},
+		{
+			name: "matching signal allows profit exit",
+			result: ConsensusResult{
+				FinalSignal:   SignalSell,
+				AvgConfidence: 0.8,
+			},
+			exitSignal:  SignalSell,
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.AllowsExit(tt.exitSignal, 0.5); got != tt.wantAllowed {
+				t.Fatalf("AllowsExit() = %v, want %v", got, tt.wantAllowed)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.8.0",
+		Version:  "v0.8.1",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -68,7 +68,7 @@ ai:
       model: "deepseek-chat"       # free tier available
     claude:
       model: "claude-3-5-haiku-20241022"  # most affordable Claude
-  min-confidence: 0.5              # minimum AI confidence to act on signal
+  min-confidence: 0.5              # entries require matching AI signal at or above this confidence
 
 # Top gainers monitor configuration
 top-gainers:

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -62,9 +62,10 @@ scalp-mode:
   atr-stop-loss: true    # dynamically widen SL based on current volatility
   atr-multiplier: 1.5    # SL = max(configured, 1.5 × ATR%)
 
-# AI — use cautiously for scalp mode due to latency; ideal for post-trade analysis and refining strategy over time rather than real-time decision-making
+# AI — disabled by default for scalp mode to avoid adding LLM latency to fast entry/exit paths.
+# Enable only if slower decisions are acceptable and you want explicit AI approval before entries.
 ai:
-  enabled: true
+  enabled: false
   providers:
     openai:
       model: "gpt-4o-mini"
@@ -72,7 +73,7 @@ ai:
       model: "deepseek-chat"
     claude:
       model: "claude-3-5-haiku-20241022"
-  min-confidence: 0.3
+  min-confidence: 0.5    # entries require matching AI signal at or above this confidence when AI is enabled
 
 top-gainers:
   quote-asset: "USDT"

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -14,9 +14,9 @@ import (
 
 	binance_connector "github.com/binance/binance-connector-go"
 	"github.com/wferreirauy/binance-bot/ai"
+	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/exchange"
 	"github.com/wferreirauy/binance-bot/indicator"
-	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/tui"
 )
 
@@ -228,7 +228,7 @@ func bearTradeLoop(
 					dash.LogError(fmt.Sprintf("AI: %v", err))
 				} else {
 					updateDashAI(dash, consensus)
-					aiApproved = consensus.ShouldSell() || consensus.FinalSignal == ai.SignalHold
+					aiApproved = consensus.ShouldSellWithMinConfidence(cfg.AI.MinConfidence)
 				}
 			}
 
@@ -485,7 +485,7 @@ func bearTradeLoop(
 					dash.LogError(fmt.Sprintf("AI buy-back: %v", err))
 				} else {
 					updateDashAI(dash, consensus)
-					aiBuyApproved = consensus.ShouldBuy() || consensus.FinalSignal == ai.SignalHold
+					aiBuyApproved = consensus.AllowsExit(ai.SignalBuy, cfg.AI.MinConfidence)
 				}
 			}
 			rsiRising := rsi[len(rsi)-1] > rsi[len(rsi)-2]

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -14,9 +14,9 @@ import (
 
 	binance_connector "github.com/binance/binance-connector-go"
 	"github.com/wferreirauy/binance-bot/ai"
+	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/exchange"
 	"github.com/wferreirauy/binance-bot/indicator"
-	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/tui"
 )
 
@@ -227,7 +227,7 @@ func bullTradeLoop(
 					dash.LogError(fmt.Sprintf("AI: %v", err))
 				} else {
 					updateDashAI(dash, consensus)
-					aiApproved = consensus.ShouldBuy() || consensus.FinalSignal == ai.SignalHold
+					aiApproved = consensus.ShouldBuyWithMinConfidence(cfg.AI.MinConfidence)
 				}
 			}
 
@@ -489,7 +489,7 @@ func bullTradeLoop(
 					dash.LogError(fmt.Sprintf("AI sell: %v", err))
 				} else {
 					updateDashAI(dash, consensus)
-					aiSellApproved = consensus.ShouldSell() || consensus.FinalSignal == ai.SignalHold
+					aiSellApproved = consensus.AllowsExit(ai.SignalSell, cfg.AI.MinConfidence)
 				}
 			}
 			rsiDeclining := rsi[len(rsi)-1] < rsi[len(rsi)-2]

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -14,9 +14,9 @@ import (
 
 	binance_connector "github.com/binance/binance-connector-go"
 	"github.com/wferreirauy/binance-bot/ai"
+	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/exchange"
 	"github.com/wferreirauy/binance-bot/indicator"
-	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/tui"
 )
 
@@ -200,29 +200,6 @@ func dynamicTradeLoop(
 						Volume: currentVolume, AvgVolume: avgVolume,
 					})
 
-					// AI analysis while waiting for tendency
-					if aiOrch != nil {
-						snapshot := &ai.TechnicalSnapshot{
-							Symbol: symbol, Price: price, PrevPrice: prevPrice,
-							RSI: rsi[len(rsi)-1], MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1],
-							PrevMACDLine: macdLine[len(macdLine)-2], PrevSignalLine: signalLine[len(signalLine)-2],
-							UpperBand: bb.UpperBand[len(bb.UpperBand)-1], LowerBand: bb.LowerBand[len(bb.LowerBand)-1],
-							DEMA: dema[len(dema)-1], Tendency: "(detecting)",
-							ADX: adxVal, Volume: currentVolume, AvgVolume: avgVolume,
-						}
-						aiMode := "BULL"
-						if strategy == "bear" {
-							aiMode = "BEAR"
-						}
-						ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-						consensus, aiErr := aiOrch.Analyze(ctx, snapshot, aiMode)
-						cancel()
-						if aiErr != nil {
-							dash.LogError(fmt.Sprintf("AI: %v", aiErr))
-						} else {
-							updateDashAI(dash, consensus)
-						}
-					}
 				}
 			}
 
@@ -393,9 +370,9 @@ func dynamicTradeLoop(
 				} else {
 					updateDashAI(dash, consensus)
 					if isBull {
-						aiApproved = consensus.ShouldBuy() || consensus.FinalSignal == ai.SignalHold
+						aiApproved = consensus.ShouldBuyWithMinConfidence(cfg.AI.MinConfidence)
 					} else {
-						aiApproved = consensus.ShouldSell() || consensus.FinalSignal == ai.SignalHold
+						aiApproved = consensus.ShouldSellWithMinConfidence(cfg.AI.MinConfidence)
 					}
 				}
 			}
@@ -741,7 +718,7 @@ func dynamicTradeLoop(
 						dash.LogError(fmt.Sprintf("AI sell: %v", err))
 					} else {
 						updateDashAI(dash, consensus)
-						aiSellApproved = consensus.ShouldSell() || consensus.FinalSignal == ai.SignalHold
+						aiSellApproved = consensus.AllowsExit(ai.SignalSell, cfg.AI.MinConfidence)
 					}
 				}
 				rsiDeclining := rsi[len(rsi)-1] < rsi[len(rsi)-2]
@@ -887,7 +864,7 @@ func dynamicTradeLoop(
 						dash.LogError(fmt.Sprintf("AI buy-back: %v", err))
 					} else {
 						updateDashAI(dash, consensus)
-						aiBuyApproved = consensus.ShouldBuy() || consensus.FinalSignal == ai.SignalHold
+						aiBuyApproved = consensus.AllowsExit(ai.SignalBuy, cfg.AI.MinConfidence)
 					}
 				}
 				rsiRising := rsi[len(rsi)-1] > rsi[len(rsi)-2]


### PR DESCRIPTION
# Harden AI trade gating and reduce scalp latency

## Summary

This patch tightens the AI consensus path so it is safer for live trading:
entries now require an explicit matching AI signal at the configured
`ai.min-confidence`, ambiguous AI output defaults to HOLD, and dynamic
auto-trade no longer spends LLM calls while it is only waiting for tendency.

## Motivation

The review found three high-impact issues in the current AI trade flow:

1. `ai.min-confidence` was documented but not used by the trade loops.
2. AI `HOLD` responses were treated as approval for new entries, allowing
   exposure even when the AI consensus was neutral or uncertain.
3. `auto-trade` queried AI while merely displaying indicators during the
   tendency-detection wait loop, adding latency/cost without influencing a
   trade decision.

These issues do not guarantee losses, but they increase false-positive entry
risk and make scalp mode slower than necessary.

## Changes

| File | Change |
|------|--------|
| `ai/agent.go` | Added configurable confidence helpers for entry gating and a conservative `AllowsExit` helper for take-profit exits. Tightened signal parsing so ambiguous lines such as `SIGNAL: BUY OR HOLD` remain HOLD instead of matching BUY by substring. |
| `ai/agent_test.go` | Added tests for exact signal parsing, configured min-confidence, and take-profit exit approval behavior. |
| `strategy/bull.go` | Entry AI approval now requires explicit BUY at `ai.min-confidence`; take-profit AI handling now uses `AllowsExit`. |
| `strategy/bear.go` | Entry AI approval now requires explicit SELL at `ai.min-confidence`; buy-back take-profit AI handling now uses `AllowsExit`. |
| `strategy/dynamic.go` | Removed the non-decision AI call from the tendency waiting loop; entry/exit AI gates now match bull/bear behavior. |
| `sample-scalp-config.yml` | Disabled AI by default for scalp mode to avoid LLM latency in fast trading paths. |
| `sample-binance-config.yml` | Clarified `ai.min-confidence` semantics. |
| `README.md` | Updated AI behavior, scalp recommendation, and help version. |
| `main.go` | Bumped version from `v0.8.0` to `v0.8.1`. |

## Behavioral impact

- With `ai.enabled: true`, entries are more selective: `HOLD`, malformed,
  low-confidence, or opposing AI output blocks new exposure.
- With `ai.enabled: false`, technical-only trading behavior is unchanged.
- Stop-loss and trailing-stop exits still execute immediately without AI.
- Take-profit exits are not blocked by HOLD or low-confidence AI output, but
  can still be blocked by a confident opposite signal.
- The sample scalp config now defaults to no AI gate for lower latency.

## Testing

```bash
go test -v ./...
go build ./...
```

Both commands pass.

## Version

`v0.8.0` -> `v0.8.1` (patch: conservative AI gating and latency reduction).

## Follow-ups

- Add deterministic unit tests around bull/bear/scalp entry scoring by moving
  the scoring logic out of the long trade loops.
- Add a max daily loss / max consecutive losing operations circuit breaker.
- Add order-fill timeout/cancel handling so stale limit orders cannot leave
  the strategy stuck indefinitely.
- Consider removing LLM confirmation from take-profit paths entirely for
  latency-sensitive configurations.