### PR TITLE
Add rotation, backtest, and managed order features

### DIFF
--- a/PR-description-draft.md
+++ b/PR-description-draft.md
@@ -1,0 +1,21 @@
+# Summary
+
+Adds the feature set inspired by `ccxt/binance-trade-bot`:
+
+- multi-asset rotation scout mode through a configurable bridge asset
+- managed order timeouts with partial-fill handling
+- fee-aware take-profit adjustment
+- persistent JSONL trade/scout/value history
+- local HTTP history API
+- backtest command backed by a small strategy registry
+
+# Documentation
+
+- Bumped CLI version to `v0.10.0`
+- Updated `README.md` with new features, commands, help output, and config sections
+- Extended both sample config files with persistence, fee, order-management, rotation, backtest, and API settings
+
+# Validation
+
+- `go test -v ./...`
+- `go build ./...`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 - **Bear Trade** — Sell-high-buy-low strategy for downtrending markets
 - **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system; no longer requires all signals simultaneously
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
+- **Rotation Scout Mode** — Scans a configured asset basket and rotates through a bridge asset when relative ratios become fee-adjusted opportunities
+- **Backtesting** — Runs registered strategy simulations over recent Binance candles before live trading
+- **Managed Orders** — Optional buy/sell timeouts with partial-fill handling for stale limit orders
+- **Persistent History API** — Stores trade/scout history in JSONL and serves it through a small local HTTP API
 - **AI Multi-Agent System** — Concurrent analysis from OpenAI, DeepSeek, and Claude with weighted consensus; when enabled, entries require explicit AI approval at the configured confidence threshold
 - **Sentiment Analysis** — Real-time news headlines and Fear & Greed Index integrated into AI decisions
 - **Trailing Stop-Loss** — Dynamically locks in profits as price moves favorably
@@ -19,6 +23,7 @@
 - **Config Validation** — Checks the YAML config file before starting a trading session
 - **Detailed Order Reasoning** — Activity Log shows which entry/exit conditions were met (✓/✗) before each trade
 - **File Logging** — All trade events and errors are written to `binance-bot.log` alongside the TUI display
+- **Fee-Aware Targets** — Take-profit thresholds can be adjusted by live Binance taker fees plus a configurable safety buffer
 
 ## Download
 
@@ -157,6 +162,30 @@ binance-bot -f binance-config.yml top-gainers
 
 Launches a real-time TUI listing the top 24h price-change gainers on Binance, filtered by quote asset, minimum volume, and an exclude list. Refreshes on the configured `poll-interval`. Press `q` to quit.
 
+#### Rotation Scout Mode
+
+```bash
+binance-bot -f binance-config.yml rotate-trade
+```
+
+Scans the configured `rotation.supported-assets` basket against `rotation.bridge-asset` and records every scout comparison to `.binance-bot/scouts.jsonl`. When a relative-ratio opportunity beats fee-adjusted thresholds, the bot rotates from the current asset into the selected asset through the bridge. The sample config runs this mode as `dry-run: true`; switch it off only after validating behavior with small balances.
+
+#### Backtest
+
+```bash
+binance-bot -f binance-config.yml backtest -t "BTC/USDT" --strategy classic-bull
+```
+
+Runs a registered strategy over recent Binance candles using the configured indicators, starting balance, and fee assumptions. Available strategies are `classic-bull` and `scalp-bull`.
+
+#### History API
+
+```bash
+binance-bot -f binance-config.yml serve
+```
+
+Starts a local HTTP server using `api.address`. Endpoints include `/api/health`, `/api/trades`, `/api/scouts`, `/api/values`, and `/api/current-asset`. Use `?limit=100` on history endpoints to read only the most recent records.
+
 #### Validate Configuration
 
 ```bash
@@ -203,7 +232,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.9.0
+     v0.10.0
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -213,6 +242,9 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      bear-trade, brt   Start a bear trade run (sell high, buy back low)
      auto-trade, at    Automatically detect market tendency and trade accordingly (bull or bear)
      top-gainers, tg   Monitor top market gainers in real-time
+     rotate-trade, rt  Scout a basket of assets and rotate through the configured bridge asset
+     backtest, btst    Backtest a registered strategy on recent Binance candles
+     serve, srv        Serve persisted trade, scout, and value history over HTTP
      validate-config, vc  Validate the configured YAML file without starting a trading session
      help, h           Shows a list of commands or help for one command
 
@@ -288,6 +320,25 @@ binance-bot -f binance-config.yml validate-config
 ```
 
 The command checks fields such as Binance candle intervals, RSI limit ordering, MACD length ordering, confidence ranges, positive refresh and polling intervals, and top-gainers settings. It reports all validation failures at once and does not call Binance or any AI provider.
+
+### Persistence, Fees, and Orders
+
+```yaml
+data-dir: ".binance-bot"
+
+order-management:
+  buy-timeout-minutes: 20
+  sell-timeout-minutes: 20
+  partial-fill-action: "keep"
+  poll-interval-secs: 5
+
+fees:
+  enabled: true
+  default-taker-pct: 0.1
+  buffer-pct: 0.05
+```
+
+The bot writes trade/scout history to `data-dir`. Managed order timeouts cancel stale limit orders; `partial-fill-action: "reverse"` attempts a market order in the opposite direction for partial timeout fills. Fee-aware mode subtracts estimated round-trip taker fees and `buffer-pct` from take-profit decisions.
 
 ### Indicators Configuration
 
@@ -386,6 +437,31 @@ top-gainers:
   exclude-symbols:         # symbols to always exclude
     - "USDCUSDT"
 ```
+
+### Rotation, Backtest, and API Configuration
+
+```yaml
+rotation:
+  bridge-asset: "USDT"
+  current-asset: "BTC"
+  supported-assets: ["BTC", "ETH", "SOL", "XRP", "DOGE"]
+  scout-multiplier: 5
+  scout-margin-pct: 0.8
+  use-margin: false
+  scout-sleep-seconds: 5
+  dry-run: true
+  max-jumps: 0
+  min-notional-buffer: 1.01
+
+backtest:
+  initial-balance: 1000
+  fee-pct: 0.1
+
+api:
+  address: "127.0.0.1:8080"
+```
+
+Rotation mode persists its current asset in `data-dir/current_asset.json`. Backtests use recent Binance candles and append simulated trade records. The API server exposes persisted JSONL history from the configured address.
 
 ### AI Configuration
 

--- a/config/file.go
+++ b/config/file.go
@@ -8,14 +8,26 @@ import (
 )
 
 type Config struct {
-	BaseURL string `yaml:"base-url"`
+	BaseURL          string `yaml:"base-url"`
+	DataDir          string `yaml:"data-dir"`
 	HistoricalPrices struct {
 		Period   int    `yaml:"period"`
 		Interval string `yaml:"interval"`
 	} `yaml:"historical-prices"`
+	OrderManagement struct {
+		BuyTimeoutMinutes  int    `yaml:"buy-timeout-minutes"`
+		SellTimeoutMinutes int    `yaml:"sell-timeout-minutes"`
+		PartialFillAction  string `yaml:"partial-fill-action"`
+		PollIntervalSecs   int    `yaml:"poll-interval-secs"`
+	} `yaml:"order-management"`
+	Fees struct {
+		Enabled         bool    `yaml:"enabled"`
+		DefaultTakerPct float64 `yaml:"default-taker-pct"`
+		BufferPct       float64 `yaml:"buffer-pct"`
+	} `yaml:"fees"`
 	Tendency struct {
-		Interval  string `yaml:"interval"`
-		Direction string `yaml:"direction"`
+		Interval    string `yaml:"interval"`
+		Direction   string `yaml:"direction"`
 		HTFEnabled  bool   `yaml:"htf-enabled"`  // enable higher-timeframe trend gate
 		HTFInterval string `yaml:"htf-interval"` // e.g. "5m", "15m" — blocks entry if HTF trend opposes trade direction
 	} `yaml:"tendency"`
@@ -56,7 +68,7 @@ type Config struct {
 		TrailingPct   float64 `yaml:"trailing-pct"`
 	} `yaml:"trailing-stop"`
 	AI struct {
-		Enabled  bool `yaml:"enabled"`
+		Enabled   bool `yaml:"enabled"`
 		Providers struct {
 			OpenAI struct {
 				Model string `yaml:"model"`
@@ -71,25 +83,44 @@ type Config struct {
 		MinConfidence float64 `yaml:"min-confidence"`
 	} `yaml:"ai"`
 	RefreshInterval int `yaml:"refresh-interval"`
-	ScalpMode struct {
+	ScalpMode       struct {
 		Enabled          bool    `yaml:"enabled"`
-		MinScore         int     `yaml:"min-score"`            // min bullish signals out of 6 to trigger entry
-		PostBuyDelay     int     `yaml:"post-buy-delay"`       // seconds to wait after buy fill before sell monitoring
-		InterOpDelay     int     `yaml:"inter-op-delay"`       // seconds to wait between operations
-		RequireRSIExit   bool    `yaml:"require-rsi-exit"`     // require RSI declining for take-profit
-		SLCooldown       bool    `yaml:"sl-cooldown"`          // enable exponential backoff after consecutive stop-losses
-		MaxConsecutiveSL int     `yaml:"max-consecutive-sl"`   // SL hits before cooldown kicks in (default: 2)
-		CooldownBaseSecs int     `yaml:"cooldown-base-secs"`   // base cooldown seconds, doubles each time (default: 60)
-		ATRStopLoss      bool    `yaml:"atr-stop-loss"`        // use ATR-based dynamic stop-loss floor
-		ATRMultiplier    float64 `yaml:"atr-multiplier"`       // SL = max(configured, atrMultiplier × ATR%) (default: 1.5)
+		MinScore         int     `yaml:"min-score"`          // min bullish signals out of 6 to trigger entry
+		PostBuyDelay     int     `yaml:"post-buy-delay"`     // seconds to wait after buy fill before sell monitoring
+		InterOpDelay     int     `yaml:"inter-op-delay"`     // seconds to wait between operations
+		RequireRSIExit   bool    `yaml:"require-rsi-exit"`   // require RSI declining for take-profit
+		SLCooldown       bool    `yaml:"sl-cooldown"`        // enable exponential backoff after consecutive stop-losses
+		MaxConsecutiveSL int     `yaml:"max-consecutive-sl"` // SL hits before cooldown kicks in (default: 2)
+		CooldownBaseSecs int     `yaml:"cooldown-base-secs"` // base cooldown seconds, doubles each time (default: 60)
+		ATRStopLoss      bool    `yaml:"atr-stop-loss"`      // use ATR-based dynamic stop-loss floor
+		ATRMultiplier    float64 `yaml:"atr-multiplier"`     // SL = max(configured, atrMultiplier × ATR%) (default: 1.5)
 	} `yaml:"scalp-mode"`
 	TopGainers struct {
-		QuoteAsset      string   `yaml:"quote-asset"`
-		Limit           int      `yaml:"limit"`
-		PollInterval    int      `yaml:"poll-interval"`
-		MinVolume       float64  `yaml:"min-volume"`
-		ExcludeSymbols  []string `yaml:"exclude-symbols"`
+		QuoteAsset     string   `yaml:"quote-asset"`
+		Limit          int      `yaml:"limit"`
+		PollInterval   int      `yaml:"poll-interval"`
+		MinVolume      float64  `yaml:"min-volume"`
+		ExcludeSymbols []string `yaml:"exclude-symbols"`
 	} `yaml:"top-gainers"`
+	Rotation struct {
+		BridgeAsset       string   `yaml:"bridge-asset"`
+		CurrentAsset      string   `yaml:"current-asset"`
+		SupportedAssets   []string `yaml:"supported-assets"`
+		ScoutMultiplier   float64  `yaml:"scout-multiplier"`
+		ScoutMarginPct    float64  `yaml:"scout-margin-pct"`
+		UseMargin         bool     `yaml:"use-margin"`
+		ScoutSleepSeconds int      `yaml:"scout-sleep-seconds"`
+		DryRun            bool     `yaml:"dry-run"`
+		MaxJumps          int      `yaml:"max-jumps"`
+		MinNotionalBuffer float64  `yaml:"min-notional-buffer"`
+	} `yaml:"rotation"`
+	Backtest struct {
+		InitialBalance float64 `yaml:"initial-balance"`
+		FeePct         float64 `yaml:"fee-pct"`
+	} `yaml:"backtest"`
+	API struct {
+		Address string `yaml:"address"`
+	} `yaml:"api"`
 }
 
 func (c *Config) Read(filePath string) (*Config, error) {

--- a/config/validation.go
+++ b/config/validation.go
@@ -17,10 +17,34 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("base-url must be a valid absolute URL"))
 		}
 	}
+	if c.DataDir == "" {
+		errs = append(errs, fmt.Errorf("data-dir must not be empty"))
+	}
 
 	errs = appendPositiveInt(errs, "historical-prices.period", c.HistoricalPrices.Period)
 	errs = appendInterval(errs, "historical-prices.interval", c.HistoricalPrices.Interval)
 	errs = appendPositiveInt(errs, "refresh-interval", c.RefreshInterval)
+
+	if c.OrderManagement.BuyTimeoutMinutes < 0 {
+		errs = append(errs, fmt.Errorf("order-management.buy-timeout-minutes must be greater than or equal to 0"))
+	}
+	if c.OrderManagement.SellTimeoutMinutes < 0 {
+		errs = append(errs, fmt.Errorf("order-management.sell-timeout-minutes must be greater than or equal to 0"))
+	}
+	if c.OrderManagement.PollIntervalSecs < 0 {
+		errs = append(errs, fmt.Errorf("order-management.poll-interval-secs must be greater than or equal to 0"))
+	}
+	switch c.OrderManagement.PartialFillAction {
+	case "", "keep", "reverse":
+	default:
+		errs = append(errs, fmt.Errorf("order-management.partial-fill-action must be \"keep\" or \"reverse\""))
+	}
+	if c.Fees.DefaultTakerPct < 0 {
+		errs = append(errs, fmt.Errorf("fees.default-taker-pct must be greater than or equal to 0"))
+	}
+	if c.Fees.BufferPct < 0 {
+		errs = append(errs, fmt.Errorf("fees.buffer-pct must be greater than or equal to 0"))
+	}
 
 	errs = appendInterval(errs, "tendency.interval", c.Tendency.Interval)
 	if c.Tendency.Direction != "up" && c.Tendency.Direction != "down" {
@@ -98,6 +122,37 @@ func (c *Config) Validate() []error {
 	errs = appendPositiveInt(errs, "top-gainers.poll-interval", c.TopGainers.PollInterval)
 	if c.TopGainers.MinVolume < 0 {
 		errs = append(errs, fmt.Errorf("top-gainers.min-volume must be greater than or equal to 0"))
+	}
+
+	if c.Rotation.BridgeAsset == "" {
+		errs = append(errs, fmt.Errorf("rotation.bridge-asset must not be empty"))
+	}
+	if len(c.Rotation.SupportedAssets) == 0 {
+		errs = append(errs, fmt.Errorf("rotation.supported-assets must include at least one asset"))
+	}
+	if c.Rotation.ScoutMultiplier <= 0 {
+		errs = append(errs, fmt.Errorf("rotation.scout-multiplier must be greater than 0"))
+	}
+	if c.Rotation.ScoutMarginPct < 0 {
+		errs = append(errs, fmt.Errorf("rotation.scout-margin-pct must be greater than or equal to 0"))
+	}
+	if c.Rotation.ScoutSleepSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("rotation.scout-sleep-seconds must be greater than 0"))
+	}
+	if c.Rotation.MaxJumps < 0 {
+		errs = append(errs, fmt.Errorf("rotation.max-jumps must be greater than or equal to 0"))
+	}
+	if c.Rotation.MinNotionalBuffer < 0 {
+		errs = append(errs, fmt.Errorf("rotation.min-notional-buffer must be greater than or equal to 0"))
+	}
+	if c.Backtest.InitialBalance <= 0 {
+		errs = append(errs, fmt.Errorf("backtest.initial-balance must be greater than 0"))
+	}
+	if c.Backtest.FeePct < 0 {
+		errs = append(errs, fmt.Errorf("backtest.fee-pct must be greater than or equal to 0"))
+	}
+	if c.API.Address == "" {
+		errs = append(errs, fmt.Errorf("api.address must not be empty"))
 	}
 
 	return errs

--- a/exchange/order.go
+++ b/exchange/order.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"time"
 
 	binance "github.com/binance/binance-connector-go"
 	"github.com/wferreirauy/binance-bot/indicator"
@@ -15,6 +16,16 @@ type SymbolFilters struct {
 	MinNotional float64
 	MinQty      float64
 	StepSize    float64
+}
+
+type ManagedOrderResult struct {
+	Order              *binance.GetOrderResponse
+	TimedOut           bool
+	Canceled           bool
+	PartiallyFilled    bool
+	ExecutedQty        float64
+	CumulativeQuoteQty float64
+	PartialHandled     bool
 }
 
 // GetSymbolFilters fetches MIN_NOTIONAL and LOT_SIZE filters from Binance exchange info.
@@ -121,4 +132,99 @@ func NewMarketOrder(symbol, side string, quantity float64) (interface{}, error) 
 	}
 	return newOrder, nil
 
+}
+
+func CancelOrder(symbol string, orderID int64) error {
+	client := binance.NewClient(APIKey, SecretKey, BaseURL)
+	_, err := client.NewCancelOrderService().Symbol(symbol).OrderId(orderID).Do(context.Background())
+	if err != nil {
+		return fmt.Errorf("order: canceling order %d: %w", orderID, err)
+	}
+	return nil
+}
+
+func GetBalance(asset string) (float64, error) {
+	client := binance.NewClient(APIKey, SecretKey, BaseURL)
+	account, err := client.NewGetAccountService().Do(context.Background())
+	if err != nil {
+		return 0, fmt.Errorf("account: %w", err)
+	}
+	for _, balance := range account.Balances {
+		if balance.Asset != asset {
+			continue
+		}
+		free, err := strconv.ParseFloat(balance.Free, 64)
+		if err != nil {
+			return 0, fmt.Errorf("balance: parse %s: %w", asset, err)
+		}
+		return free, nil
+	}
+	return 0, nil
+}
+
+func GetTradeFeePct(symbol string, defaultPct float64) float64 {
+	client := binance.NewClient(APIKey, SecretKey, BaseURL)
+	fees, err := client.NewTradeFeeService().Symbol(symbol).Do(context.Background())
+	if err != nil || len(fees) == 0 {
+		return defaultPct
+	}
+	taker, err := strconv.ParseFloat(fees[0].TakerCommission, 64)
+	if err != nil {
+		return defaultPct
+	}
+	return taker * 100
+}
+
+func NetTargetPct(targetPct, feePct, bufferPct float64) float64 {
+	net := targetPct - 2*feePct - bufferPct
+	if net < 0 {
+		return 0
+	}
+	return net
+}
+
+func WaitForManagedOrder(symbol string, orderID int64, side string, timeout time.Duration, pollInterval time.Duration, partialFillAction string) (*ManagedOrderResult, error) {
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+	started := time.Now()
+	for {
+		order, err := GetOrder(symbol, orderID)
+		if err != nil {
+			return nil, err
+		}
+		executedQty, _ := strconv.ParseFloat(order.ExecutedQty, 64)
+		cumulativeQuoteQty, _ := strconv.ParseFloat(order.CumulativeQuoteQty, 64)
+		result := &ManagedOrderResult{
+			Order:              order,
+			ExecutedQty:        executedQty,
+			CumulativeQuoteQty: cumulativeQuoteQty,
+			PartiallyFilled:    executedQty > 0 && order.Status != "FILLED",
+		}
+		switch order.Status {
+		case "FILLED":
+			return result, nil
+		case "CANCELED", "REJECTED", "EXPIRED":
+			return result, nil
+		}
+		if timeout > 0 && time.Since(started) >= timeout {
+			result.TimedOut = true
+			if err := CancelOrder(symbol, orderID); err != nil {
+				return result, err
+			}
+			result.Canceled = true
+			if result.PartiallyFilled && partialFillAction == "reverse" {
+				reverseSide := "SELL"
+				if side == "SELL" {
+					reverseSide = "BUY"
+				}
+				if _, err := NewMarketOrder(symbol, reverseSide, executedQty); err != nil {
+					return result, err
+				}
+				result.PartialHandled = true
+			}
+			return result, nil
+		}
+		time.Sleep(pollInterval)
+	}
 }

--- a/exchange/price.go
+++ b/exchange/price.go
@@ -2,9 +2,11 @@ package exchange
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +32,34 @@ func GetPrice(client *binance_connector.Client, symbol string) (float64, error) 
 		return price, nil
 	}
 	return 0.0, fmt.Errorf("price: could not get price: %w", err)
+}
+
+func GetAllTickerPrices(client *binance_connector.Client) (map[string]float64, error) {
+	resp, err := http.Get(BaseURL + "/api/v3/ticker/price")
+	if err != nil {
+		return nil, fmt.Errorf("price: could not get all prices: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("price: read all prices: %w", err)
+	}
+	var prices []struct {
+		Symbol string `json:"symbol"`
+		Price  string `json:"price"`
+	}
+	if err := json.Unmarshal(body, &prices); err != nil {
+		return nil, fmt.Errorf("price: decode all prices: %w", err)
+	}
+	out := make(map[string]float64, len(prices))
+	for _, p := range prices {
+		price, err := strconv.ParseFloat(p.Price, 64)
+		if err != nil {
+			continue
+		}
+		out[p.Symbol] = price
+	}
+	return out, nil
 }
 
 // PrintPrice prints the current ticker price with color formatting

--- a/main.go
+++ b/main.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/server"
 	"github.com/wferreirauy/binance-bot/strategy"
 )
 
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.9.0",
+		Version:  "v0.10.0",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{
@@ -249,6 +250,46 @@ func main() {
 				Action: func(cCtx *cli.Context) error {
 					strategy.TopGainers(cCtx.String("config-file"))
 					return nil
+				},
+			},
+			{
+				Name:    "rotate-trade",
+				Usage:   "Scout a basket of assets and rotate through the configured bridge asset",
+				Aliases: []string{"rt"},
+				Action: func(cCtx *cli.Context) error {
+					strategy.RotationTrade(cCtx.String("config-file"))
+					return nil
+				},
+			},
+			{
+				Name:    "backtest",
+				Usage:   "Backtest a registered strategy on recent Binance candles",
+				Aliases: []string{"btst"},
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "ticker",
+						Usage:    "ticker to backtest, format ABC/USD eg. BTC/USDT",
+						Aliases:  []string{"t"},
+						Required: true,
+					},
+					&cli.StringFlag{
+						Name:    "strategy",
+						Usage:   "registered strategy name",
+						Value:   "classic-bull",
+						Aliases: []string{"st"},
+					},
+				},
+				Action: func(cCtx *cli.Context) error {
+					strategy.Backtest(cCtx.String("config-file"), cCtx.String("ticker"), cCtx.String("strategy"))
+					return nil
+				},
+			},
+			{
+				Name:    "serve",
+				Usage:   "Serve persisted trade, scout, and value history over HTTP",
+				Aliases: []string{"srv"},
+				Action: func(cCtx *cli.Context) error {
+					return server.Serve(cCtx.String("config-file"))
 				},
 			},
 			{

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -3,11 +3,24 @@
 # Binance API base URL (default: https://api1.binance.com)
 # Use https://testnet.binance.vision for testnet
 base-url: "https://api1.binance.com"
+data-dir: ".binance-bot"
 
 historical-prices:
   period: 100
   interval: "1m"
 refresh-interval: 10  # seconds between price checks (default: 10)
+
+order-management:
+  buy-timeout-minutes: 20     # cancel unfilled buy limit orders after this many minutes; 0 disables timeout
+  sell-timeout-minutes: 20    # cancel unfilled sell limit orders after this many minutes; 0 disables timeout
+  partial-fill-action: "keep" # keep or reverse partially filled timeout orders
+  poll-interval-secs: 5       # order status polling cadence
+
+fees:
+  enabled: true
+  default-taker-pct: 0.1      # fallback taker fee percent when Binance fee lookup is unavailable
+  buffer-pct: 0.05            # extra target buffer subtracted from take-profit decisions
+
 tendency:
   interval: "3m"
   direction: "up"
@@ -78,3 +91,27 @@ top-gainers:
   min-volume: 1000000              # minimum 24h quote volume to include
   exclude-symbols:                 # symbols to exclude from results
     - "USDCUSDT"
+
+rotation:
+  bridge-asset: "USDT"
+  current-asset: "BTC"              # initial asset; persisted state overrides this after first run
+  supported-assets:
+    - "BTC"
+    - "ETH"
+    - "SOL"
+    - "XRP"
+    - "DOGE"
+  scout-multiplier: 5               # fee multiplier used by relative-ratio scout mode
+  scout-margin-pct: 0.8             # used when use-margin is true
+  use-margin: false
+  scout-sleep-seconds: 5
+  dry-run: true                     # set false only after testing with small balances
+  max-jumps: 0                      # 0 means run until stopped
+  min-notional-buffer: 1.01
+
+backtest:
+  initial-balance: 1000
+  fee-pct: 0.1
+
+api:
+  address: "127.0.0.1:8080"

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -7,12 +7,24 @@
 # Binance API base URL (default: https://api1.binance.com)
 # Use https://testnet.binance.vision for testnet
 base-url: "https://api1.binance.com"
+data-dir: ".binance-bot"
 
 historical-prices:
   period: 50            # shorter lookback → faster indicator response
   interval: "1m"        # 1-minute candles for rapid signals
 
 refresh-interval: 10    # poll every 10 seconds for faster reaction to market changes
+
+order-management:
+  buy-timeout-minutes: 5
+  sell-timeout-minutes: 5
+  partial-fill-action: "keep"
+  poll-interval-secs: 2
+
+fees:
+  enabled: true
+  default-taker-pct: 0.1
+  buffer-pct: 0.05
 
 tendency:
   interval: "1m"        # fast tendency on 1m (was 3m)
@@ -82,3 +94,26 @@ top-gainers:
   min-volume: 5000000    # higher volume filter for liquid scalp targets
   exclude-symbols:
     - "USDCUSDT"
+
+rotation:
+  bridge-asset: "USDT"
+  current-asset: "DOGE"
+  supported-assets:
+    - "DOGE"
+    - "PEPE"
+    - "SHIB"
+    - "XRP"
+  scout-multiplier: 5
+  scout-margin-pct: 0.8
+  use-margin: false
+  scout-sleep-seconds: 3
+  dry-run: true
+  max-jumps: 0
+  min-notional-buffer: 1.01
+
+backtest:
+  initial-balance: 1000
+  fee-pct: 0.1
+
+api:
+  address: "127.0.0.1:8080"

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/storage"
+)
+
+func Serve(configFile string) error {
+	var c config.Config
+	cfg, err := c.Read(configFile)
+	if err != nil {
+		return err
+	}
+	addr := cfg.API.Address
+	if addr == "" {
+		addr = "127.0.0.1:8080"
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/api/trades", func(w http.ResponseWriter, r *http.Request) {
+		limit := limitParam(r)
+		records, err := storage.ReadJSONL[storage.TradeRecord](cfg.DataDir, storage.TradesFile, limit)
+		writeResponse(w, records, err)
+	})
+	mux.HandleFunc("/api/scouts", func(w http.ResponseWriter, r *http.Request) {
+		limit := limitParam(r)
+		records, err := storage.ReadJSONL[storage.ScoutRecord](cfg.DataDir, storage.ScoutsFile, limit)
+		writeResponse(w, records, err)
+	})
+	mux.HandleFunc("/api/values", func(w http.ResponseWriter, r *http.Request) {
+		limit := limitParam(r)
+		records, err := storage.ReadJSONL[storage.ValueRecord](cfg.DataDir, storage.ValuesFile, limit)
+		writeResponse(w, records, err)
+	})
+	mux.HandleFunc("/api/current-asset", func(w http.ResponseWriter, r *http.Request) {
+		store, err := storage.New(cfg.DataDir)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		asset, ok, err := store.CurrentAsset()
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, map[string]any{"asset": asset, "set": ok})
+	})
+	log.Printf("History API listening on http://%s", addr)
+	return http.ListenAndServe(addr, mux)
+}
+
+func limitParam(r *http.Request) int {
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	return limit
+}
+
+func writeResponse(w http.ResponseWriter, value any, err error) {
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, value)
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+}

--- a/storage/jsonl.go
+++ b/storage/jsonl.go
@@ -1,0 +1,169 @@
+package storage
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	TradesFile       = "trades.jsonl"
+	ScoutsFile       = "scouts.jsonl"
+	ValuesFile       = "values.jsonl"
+	CurrentAssetFile = "current_asset.json"
+)
+
+type Store struct {
+	dir string
+}
+
+type TradeRecord struct {
+	Time           time.Time `json:"time"`
+	Symbol         string    `json:"symbol"`
+	Side           string    `json:"side"`
+	OrderID        int64     `json:"order_id,omitempty"`
+	Status         string    `json:"status"`
+	Quantity       float64   `json:"quantity"`
+	Price          float64   `json:"price"`
+	QuoteQuantity  float64   `json:"quote_quantity,omitempty"`
+	Reason         string    `json:"reason,omitempty"`
+	Mode           string    `json:"mode,omitempty"`
+	Operation      int       `json:"operation,omitempty"`
+	ExecutedQty    float64   `json:"executed_qty,omitempty"`
+	PartialHandled bool      `json:"partial_handled,omitempty"`
+}
+
+type ScoutRecord struct {
+	Time          time.Time `json:"time"`
+	FromAsset     string    `json:"from_asset"`
+	ToAsset       string    `json:"to_asset"`
+	BridgeAsset   string    `json:"bridge_asset"`
+	FromPrice     float64   `json:"from_price"`
+	ToPrice       float64   `json:"to_price"`
+	BaselineRatio float64   `json:"baseline_ratio"`
+	CurrentRatio  float64   `json:"current_ratio"`
+	Opportunity   float64   `json:"opportunity"`
+	TradeFeePct   float64   `json:"trade_fee_pct"`
+	Selected      bool      `json:"selected"`
+}
+
+type ValueRecord struct {
+	Time        time.Time `json:"time"`
+	Asset       string    `json:"asset"`
+	Balance     float64   `json:"balance"`
+	BridgeAsset string    `json:"bridge_asset"`
+	BridgeValue float64   `json:"bridge_value"`
+}
+
+func New(dir string) (*Store, error) {
+	if dir == "" {
+		dir = ".binance-bot"
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("storage: create data dir: %w", err)
+	}
+	return &Store{dir: dir}, nil
+}
+
+func (s *Store) Dir() string {
+	return s.dir
+}
+
+func (s *Store) AppendTrade(record TradeRecord) error {
+	if record.Time.IsZero() {
+		record.Time = time.Now()
+	}
+	return s.appendJSONL(TradesFile, record)
+}
+
+func (s *Store) AppendScout(record ScoutRecord) error {
+	if record.Time.IsZero() {
+		record.Time = time.Now()
+	}
+	return s.appendJSONL(ScoutsFile, record)
+}
+
+func (s *Store) AppendValue(record ValueRecord) error {
+	if record.Time.IsZero() {
+		record.Time = time.Now()
+	}
+	return s.appendJSONL(ValuesFile, record)
+}
+
+func (s *Store) SetCurrentAsset(asset string) error {
+	payload := struct {
+		Asset string    `json:"asset"`
+		Time  time.Time `json:"time"`
+	}{Asset: asset, Time: time.Now()}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("storage: encode current asset: %w", err)
+	}
+	return os.WriteFile(filepath.Join(s.dir, CurrentAssetFile), append(data, '\n'), 0o644)
+}
+
+func (s *Store) CurrentAsset() (string, bool, error) {
+	data, err := os.ReadFile(filepath.Join(s.dir, CurrentAssetFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("storage: read current asset: %w", err)
+	}
+	payload := struct {
+		Asset string `json:"asset"`
+	}{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", false, fmt.Errorf("storage: decode current asset: %w", err)
+	}
+	return payload.Asset, payload.Asset != "", nil
+}
+
+func ReadJSONL[T any](dir, name string, limit int) ([]T, error) {
+	path := filepath.Join(dir, name)
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []T{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("storage: open %s: %w", name, err)
+	}
+	defer file.Close()
+
+	var records []T
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var record T
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			return nil, fmt.Errorf("storage: decode %s: %w", name, err)
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("storage: scan %s: %w", name, err)
+	}
+	if limit > 0 && len(records) > limit {
+		return records[len(records)-limit:], nil
+	}
+	return records, nil
+}
+
+func (s *Store) appendJSONL(name string, record any) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("storage: encode %s: %w", name, err)
+	}
+	file, err := os.OpenFile(filepath.Join(s.dir, name), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("storage: open %s: %w", name, err)
+	}
+	defer file.Close()
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("storage: append %s: %w", name, err)
+	}
+	return nil
+}

--- a/strategy/backtest.go
+++ b/strategy/backtest.go
@@ -1,0 +1,155 @@
+package strategy
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	binance_connector "github.com/binance/binance-connector-go"
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/exchange"
+	"github.com/wferreirauy/binance-bot/indicator"
+	"github.com/wferreirauy/binance-bot/storage"
+)
+
+type BacktestResult struct {
+	Symbol       string
+	Strategy     string
+	Trades       int
+	Wins         int
+	Losses       int
+	StartBalance float64
+	EndBalance   float64
+	ReturnPct    float64
+	LastClose    float64
+}
+
+func Backtest(configFile, symbol, strategyName string) {
+	var c config.Config
+	cfg, err := c.Read(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
+	if strategyName == "" {
+		strategyName = "classic-bull"
+	}
+	result, err := RunBacktest(cfg, symbol, strategyName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Backtest %s using %s\n", result.Symbol, result.Strategy)
+	fmt.Printf("Trades: %d | Wins: %d | Losses: %d\n", result.Trades, result.Wins, result.Losses)
+	fmt.Printf("Balance: %.4f -> %.4f (return %+.2f%%)\n", result.StartBalance, result.EndBalance, result.ReturnPct)
+	fmt.Printf("Last close: %.8f\n", result.LastClose)
+}
+
+func RunBacktest(cfg *config.Config, symbol, strategyName string) (*BacktestResult, error) {
+	def, err := GetStrategy(strategyName)
+	if err != nil {
+		return nil, err
+	}
+	ticker := strings.Replace(symbol, "/", "", -1)
+	client := binance_connector.NewClient(exchange.APIKey, exchange.SecretKey, exchange.BaseURL)
+	period := cfg.HistoricalPrices.Period
+	if period < 60 {
+		period = 60
+	}
+	ohlcv, err := exchange.GetHistoricalOHLCV(client, ticker, cfg.HistoricalPrices.Interval, period)
+	if err != nil {
+		return nil, fmt.Errorf("backtest: fetch OHLCV: %w", err)
+	}
+	initial := cfg.Backtest.InitialBalance
+	if initial <= 0 {
+		initial = 1000
+	}
+	feePct := cfg.Backtest.FeePct
+	if feePct <= 0 {
+		feePct = cfg.Fees.DefaultTakerPct
+	}
+	balance := initial
+	var qty, entryPrice float64
+	var position bool
+	var trades, wins, losses int
+	store, _ := storage.New(cfg.DataDir)
+
+	for i := 30; i < len(ohlcv.Closes); i++ {
+		tendency := calculateBacktestTendency(ohlcv.Closes[:i+1])
+		signal := def.Decide(MarketSnapshot{
+			Symbol:     symbol,
+			Index:      i,
+			OHLCV:      ohlcv,
+			Tendency:   tendency,
+			Config:     cfg,
+			Position:   position,
+			EntryPrice: entryPrice,
+		})
+		price := ohlcv.Closes[i]
+		switch signal {
+		case SignalBuy:
+			if position {
+				continue
+			}
+			qty = (balance * (1 - feePct/100)) / price
+			entryPrice = price
+			position = true
+			trades++
+			if store != nil {
+				_ = store.AppendTrade(storage.TradeRecord{Symbol: ticker, Side: "BUY", Status: "BACKTEST", Quantity: qty, Price: price, QuoteQuantity: balance, Reason: strategyName, Operation: trades})
+			}
+		case SignalSell:
+			if !position {
+				continue
+			}
+			exitValue := qty * price * (1 - feePct/100)
+			if exitValue > balance {
+				wins++
+			} else {
+				losses++
+			}
+			balance = exitValue
+			position = false
+			if store != nil {
+				_ = store.AppendTrade(storage.TradeRecord{Symbol: ticker, Side: "SELL", Status: "BACKTEST", Quantity: qty, Price: price, QuoteQuantity: balance, Reason: strategyName, Operation: trades})
+			}
+		}
+	}
+	if position && len(ohlcv.Closes) > 0 {
+		balance = qty * ohlcv.Closes[len(ohlcv.Closes)-1] * (1 - feePct/100)
+	}
+	return &BacktestResult{
+		Symbol:       symbol,
+		Strategy:     strategyName,
+		Trades:       trades,
+		Wins:         wins,
+		Losses:       losses,
+		StartBalance: initial,
+		EndBalance:   balance,
+		ReturnPct:    (balance/initial - 1) * 100,
+		LastClose:    ohlcv.Closes[len(ohlcv.Closes)-1],
+	}, nil
+}
+
+func calculateBacktestTendency(closes []float64) string {
+	if len(closes) < 10 {
+		return "up"
+	}
+	dema := indicator.CalculateDEMA(closes, 9)
+	sma := indicator.CalculateSMA(closes, minInt(30, len(closes)))
+	if len(dema) == 0 || len(sma) == 0 {
+		return "up"
+	}
+	if dema[len(dema)-1] >= sma[len(sma)-1] {
+		return "up"
+	}
+	return "down"
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -128,6 +128,7 @@ func bearTradeLoop(
 	var sellPrice float64
 	var operation = 1
 	var consecutiveSL int // tracks consecutive stop-loss exits for cooldown
+	takeProfit = feeAdjustedTakeProfit(symbol, cfg, takeProfit, dash)
 
 	for range max_ops {
 		dash.SetOperation(operation)
@@ -356,7 +357,7 @@ func bearTradeLoop(
 					dash.LogInfo(fmt.Sprintf("SELL order #%d - Status: %s", getor.OrderId, getor.Status))
 				}
 
-				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval)
+				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
 				break
 			}
 			time.Sleep(refreshInterval)
@@ -423,7 +424,7 @@ func bearTradeLoop(
 						orderId := buyOrder.FieldByName("OrderId").Int()
 						dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET BUY[-] %f %s @ ~[white::b]%.*f[-] %s",
 							buyBackQty, scoin, roundPrice, price, dcoin))
-						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval)
+						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg)
 						exitType = "ts"
 						break
 					}
@@ -465,7 +466,7 @@ func bearTradeLoop(
 				orderId := buyOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 					buyBackQty, scoin, roundPrice, price, dcoin, effectiveSL))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval)
+				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg)
 				exitType = "sl"
 				break
 			}
@@ -509,7 +510,7 @@ func bearTradeLoop(
 				orderId := buyOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[green::b]BUY[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 					buyBackQty, scoin, roundPrice, price, dcoin, roundPrice, price*buyBackQty, dcoin))
-				waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval)
+				waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg)
 				exitType = "tp"
 				break
 			}

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -127,6 +127,7 @@ func bullTradeLoop(
 	var buyPrice float64
 	var operation = 1
 	var consecutiveSL int // tracks consecutive stop-loss exits for cooldown
+	takeProfit = feeAdjustedTakeProfit(symbol, cfg, takeProfit, dash)
 
 	for range max_ops {
 		dash.SetOperation(operation)
@@ -355,15 +356,7 @@ func bullTradeLoop(
 					dash.LogInfo(fmt.Sprintf("BUY order #%d - Status: %s", getor.OrderId, getor.Status))
 				}
 
-				for {
-					if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
-						if getor.Status == "FILLED" {
-							dash.LogOrder("[green::b]BUY order filled![-]")
-							break
-						}
-					}
-					time.Sleep(refreshInterval)
-				}
+				waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg)
 				break
 			}
 			time.Sleep(refreshInterval)
@@ -428,7 +421,7 @@ func bullTradeLoop(
 						orderId := sellOrder.FieldByName("OrderId").Int()
 						dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET SELL[-] %f %s @ ~[white::b]%.*f[-] %s",
 							qty, scoin, roundPrice, price, dcoin))
-						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval)
+						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg)
 						exitType = "ts"
 						break
 					}
@@ -469,7 +462,7 @@ func bullTradeLoop(
 				orderId := sellOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 					qty, scoin, roundPrice, price, dcoin, effectiveSL))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval)
+				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg)
 				exitType = "sl"
 				break
 			}
@@ -512,7 +505,7 @@ func bullTradeLoop(
 				orderId := sellOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]SELL[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 					qty, scoin, roundPrice, price, dcoin, roundPrice, price*qty, dcoin))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval)
+				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
 				exitType = "tp"
 				break
 			}

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -147,6 +147,7 @@ func dynamicTradeLoop(
 ) {
 	var operation = 1
 	var consecutiveSL int
+	takeProfit = feeAdjustedTakeProfit(symbol, cfg, takeProfit, dash)
 
 	for range max_ops {
 		dash.SetOperation(operation)
@@ -572,7 +573,7 @@ func dynamicTradeLoop(
 					if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 						dash.LogInfo(fmt.Sprintf("BUY order #%d - Status: %s", getor.OrderId, getor.Status))
 					}
-					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg)
 				} else {
 					dash.SetPhase("SELLING")
 					sell, err := TradeSell(symbol, qty, price, sellFactor, roundPrice)
@@ -591,7 +592,7 @@ func dynamicTradeLoop(
 					if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 						dash.LogInfo(fmt.Sprintf("SELL order #%d - Status: %s", getor.OrderId, getor.Status))
 					}
-					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL order filled![-]", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL order filled![-]", refreshInterval, cfg)
 				}
 				break
 			}
@@ -657,7 +658,7 @@ func dynamicTradeLoop(
 							orderId := sellOrder.FieldByName("OrderId").Int()
 							dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET SELL[-] %f %s @ ~[white::b]%.*f[-] %s",
 								qty, scoin, roundPrice, price, dcoin))
-							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval)
+							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg)
 							exitType = "ts"
 							break
 						}
@@ -698,7 +699,7 @@ func dynamicTradeLoop(
 					orderId := sellOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 						qty, scoin, roundPrice, price, dcoin, effectiveSL))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg)
 					exitType = "sl"
 					break
 				}
@@ -741,7 +742,7 @@ func dynamicTradeLoop(
 					orderId := sellOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]SELL[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 						qty, scoin, roundPrice, price, dcoin, roundPrice, price*qty, dcoin))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
 					exitType = "tp"
 					break
 				}
@@ -802,7 +803,7 @@ func dynamicTradeLoop(
 							orderId := buyOrder.FieldByName("OrderId").Int()
 							dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET BUY[-] %f %s @ ~[white::b]%.*f[-] %s",
 								buyBackQty, scoin, roundPrice, price, dcoin))
-							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval)
+							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg)
 							exitType = "ts"
 							break
 						}
@@ -844,7 +845,7 @@ func dynamicTradeLoop(
 					orderId := buyOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 						buyBackQty, scoin, roundPrice, price, dcoin, effectiveSL))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg)
 					exitType = "sl"
 					break
 				}
@@ -888,7 +889,7 @@ func dynamicTradeLoop(
 					orderId := buyOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[green::b]BUY[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 						buyBackQty, scoin, roundPrice, price, dcoin, roundPrice, price*buyBackQty, dcoin))
-					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval)
+					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg)
 					exitType = "tp"
 					break
 				}

--- a/strategy/helpers.go
+++ b/strategy/helpers.go
@@ -3,6 +3,8 @@ package strategy
 import (
 	"fmt"
 	"os"
+	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/exchange"
 	"github.com/wferreirauy/binance-bot/indicator"
+	"github.com/wferreirauy/binance-bot/storage"
 	"github.com/wferreirauy/binance-bot/tui"
 )
 
@@ -95,6 +98,59 @@ func TradeMarketSell(ticker string, qty, estimatedPrice float64, round uint) (an
 	return order, nil
 }
 
+func dataStore(cfg *config.Config) *storage.Store {
+	if cfg == nil {
+		return nil
+	}
+	store, err := storage.New(cfg.DataDir)
+	if err != nil {
+		return nil
+	}
+	return store
+}
+
+func orderIDAndPrice(order any) (int64, float64) {
+	v := reflect.ValueOf(order)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	var id int64
+	var price float64
+	if f := v.FieldByName("OrderId"); f.IsValid() && f.CanInt() {
+		id = f.Int()
+	}
+	if f := v.FieldByName("Price"); f.IsValid() && f.Kind() == reflect.String {
+		price, _ = strconv.ParseFloat(f.String(), 64)
+	}
+	return id, price
+}
+
+func feeAdjustedTakeProfit(ticker string, cfg *config.Config, takeProfit float64, dash *tui.Dashboard) float64 {
+	if cfg == nil || !cfg.Fees.Enabled {
+		return takeProfit
+	}
+	symbol := strings.Replace(ticker, "/", "", -1)
+	defaultFee := cfg.Fees.DefaultTakerPct
+	if defaultFee <= 0 {
+		defaultFee = 0.1
+	}
+	feePct := exchange.GetTradeFeePct(symbol, defaultFee)
+	netTP := exchange.NetTargetPct(takeProfit, feePct, cfg.Fees.BufferPct)
+	if dash != nil && netTP != takeProfit {
+		dash.LogInfo(fmt.Sprintf("[yellow]Fee-aware TP[-] %.2f%% gross -> %.2f%% net target (fee %.4f%% x2, buffer %.2f%%)",
+			takeProfit, netTP, feePct, cfg.Fees.BufferPct))
+	}
+	return netTP
+}
+
+func recordTrade(cfg *config.Config, record storage.TradeRecord) {
+	store := dataStore(cfg)
+	if store == nil {
+		return
+	}
+	_ = store.AppendTrade(record)
+}
+
 // updateDashAI converts an ai.ConsensusResult into tui.AIConsensusData and updates the dashboard.
 func updateDashAI(dash *tui.Dashboard, cr *ai.ConsensusResult) {
 	data := &tui.AIConsensusData{
@@ -144,7 +200,70 @@ func logEntryConditions(dash *tui.Dashboard, mode string, conditions []entryCond
 }
 
 // waitOrderFilled polls until an order is filled, logging the result.
-func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMsg string, interval time.Duration) {
+func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMsg string, interval time.Duration, cfgs ...*config.Config) {
+	var cfg *config.Config
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	timeout := time.Duration(0)
+	pollInterval := interval
+	partialFillAction := "keep"
+	if cfg != nil {
+		timeoutMinutes := cfg.OrderManagement.BuyTimeoutMinutes
+		if strings.Contains(strings.ToUpper(filledMsg), "SELL") {
+			timeoutMinutes = cfg.OrderManagement.SellTimeoutMinutes
+		}
+		if timeoutMinutes > 0 {
+			timeout = time.Duration(timeoutMinutes) * time.Minute
+		}
+		if cfg.OrderManagement.PollIntervalSecs > 0 {
+			pollInterval = time.Duration(cfg.OrderManagement.PollIntervalSecs) * time.Second
+		}
+		if cfg.OrderManagement.PartialFillAction != "" {
+			partialFillAction = cfg.OrderManagement.PartialFillAction
+		}
+	}
+	if cfg != nil && timeout > 0 {
+		side := "BUY"
+		if strings.Contains(strings.ToUpper(filledMsg), "SELL") {
+			side = "SELL"
+		}
+		result, err := exchange.WaitForManagedOrder(ticker, orderId, side, timeout, pollInterval, partialFillAction)
+		if err != nil {
+			dash.LogError(fmt.Sprintf("Order #%d wait failed: %v", orderId, err))
+			return
+		}
+		if result.Order != nil {
+			price, _ := strconv.ParseFloat(result.Order.Price, 64)
+			recordTrade(cfg, storage.TradeRecord{
+				Symbol:         ticker,
+				Side:           result.Order.Side,
+				OrderID:        orderId,
+				Status:         result.Order.Status,
+				Quantity:       result.ExecutedQty,
+				Price:          price,
+				QuoteQuantity:  result.CumulativeQuoteQty,
+				Reason:         "order-status",
+				ExecutedQty:    result.ExecutedQty,
+				PartialHandled: result.PartialHandled,
+			})
+			if result.Order.Status == "FILLED" {
+				dash.LogOrder(filledMsg)
+				return
+			}
+		}
+		if result.TimedOut {
+			dash.LogInfo(fmt.Sprintf("[yellow]Order #%d timed out and was canceled[-]", orderId))
+			if result.PartialHandled {
+				dash.LogInfo(fmt.Sprintf("[yellow]Partial fill on order #%d was reversed with a market order[-]", orderId))
+			}
+			return
+		}
+		if result.Order != nil {
+			dash.LogInfo(fmt.Sprintf("[yellow]Order #%d ended with status %s[-]", orderId, result.Order.Status))
+		}
+		return
+	}
 	for {
 		if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 			if getor.Status == "FILLED" {

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -1,0 +1,156 @@
+package strategy
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/exchange"
+	"github.com/wferreirauy/binance-bot/indicator"
+)
+
+type Signal string
+
+const (
+	SignalBuy  Signal = "BUY"
+	SignalSell Signal = "SELL"
+	SignalHold Signal = "HOLD"
+)
+
+type MarketSnapshot struct {
+	Symbol     string
+	Index      int
+	OHLCV      *exchange.OHLCV
+	Tendency   string
+	Config     *config.Config
+	Position   bool
+	EntryPrice float64
+}
+
+type StrategyDefinition interface {
+	Name() string
+	Decide(snapshot MarketSnapshot) Signal
+}
+
+var registeredStrategies = map[string]StrategyDefinition{}
+
+func RegisterStrategy(def StrategyDefinition) {
+	registeredStrategies[def.Name()] = def
+}
+
+func GetStrategy(name string) (StrategyDefinition, error) {
+	def, ok := registeredStrategies[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown strategy %q; available: %v", name, StrategyNames())
+	}
+	return def, nil
+}
+
+func StrategyNames() []string {
+	names := make([]string, 0, len(registeredStrategies))
+	for name := range registeredStrategies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+type classicBullStrategy struct{}
+
+func (classicBullStrategy) Name() string { return "classic-bull" }
+
+func (classicBullStrategy) Decide(snapshot MarketSnapshot) Signal {
+	cfg := snapshot.Config
+	ohlcv := snapshot.OHLCV
+	i := snapshot.Index
+	if i < 2 || i >= len(ohlcv.Closes) {
+		return SignalHold
+	}
+	closes := ohlcv.Closes[:i+1]
+	dema := indicator.CalculateDEMA(closes, cfg.Indicators.Dema.Length)
+	rsi := indicator.CalculateRSI(closes, cfg.Indicators.Rsi.Length)
+	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
+	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
+		return SignalHold
+	}
+	price := closes[len(closes)-1]
+	if snapshot.Position {
+		if price <= snapshot.EntryPrice*(1-snapshot.Config.Backtest.FeePct/100) {
+			return SignalHold
+		}
+		return SignalSell
+	}
+	currentDema := dema[len(dema)-1]
+	lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
+	upperBand := bb.UpperBand[len(bb.UpperBand)-1]
+	distanceToUpper := math.Abs(currentDema - upperBand)
+	distanceToLower := math.Abs(currentDema - lowerBand)
+	macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
+		macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
+	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) &&
+		macdCrossOk &&
+		snapshot.Tendency == "up" &&
+		distanceToLower < distanceToUpper {
+		return SignalBuy
+	}
+	return SignalHold
+}
+
+type scalpBullStrategy struct{}
+
+func (scalpBullStrategy) Name() string { return "scalp-bull" }
+
+func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
+	cfg := snapshot.Config
+	ohlcv := snapshot.OHLCV
+	i := snapshot.Index
+	if i < 2 || i >= len(ohlcv.Closes) {
+		return SignalHold
+	}
+	price := ohlcv.Closes[i]
+	if snapshot.Position {
+		if price >= snapshot.EntryPrice*(1+cfg.Backtest.FeePct/100) {
+			return SignalSell
+		}
+		return SignalHold
+	}
+	closes := ohlcv.Closes[:i+1]
+	dema := indicator.CalculateDEMA(closes, cfg.Indicators.Dema.Length)
+	rsi := indicator.CalculateRSI(closes, cfg.Indicators.Rsi.Length)
+	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
+	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) == 0 || len(signalLine) == 0 || len(bb.LowerBand) == 0 {
+		return SignalHold
+	}
+	score := 0
+	currentDema := dema[len(dema)-1]
+	lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
+	upperBand := bb.UpperBand[len(bb.UpperBand)-1]
+	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) {
+		score++
+	}
+	if macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] {
+		score++
+	}
+	if snapshot.Tendency == "up" {
+		score++
+	}
+	if math.Abs(currentDema-lowerBand) < math.Abs(currentDema-upperBand) {
+		score++
+	}
+	minScore := cfg.ScalpMode.MinScore
+	if minScore <= 0 {
+		minScore = 3
+	}
+	if score >= minScore {
+		return SignalBuy
+	}
+	return SignalHold
+}
+
+func init() {
+	RegisterStrategy(classicBullStrategy{})
+	RegisterStrategy(scalpBullStrategy{})
+}

--- a/strategy/rotation.go
+++ b/strategy/rotation.go
@@ -1,0 +1,239 @@
+package strategy
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strings"
+	"time"
+
+	binance_connector "github.com/binance/binance-connector-go"
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/exchange"
+	"github.com/wferreirauy/binance-bot/storage"
+)
+
+type rotationPair struct {
+	FromAsset     string
+	ToAsset       string
+	BaselineRatio float64
+}
+
+func RotationTrade(configFile string) {
+	var c config.Config
+	cfg, err := c.Read(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if cfg.BaseURL != "" {
+		exchange.BaseURL = cfg.BaseURL
+	}
+	if err := runRotation(cfg); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runRotation(cfg *config.Config) error {
+	store, err := storage.New(cfg.DataDir)
+	if err != nil {
+		return err
+	}
+	bridge := strings.ToUpper(cfg.Rotation.BridgeAsset)
+	assets := normalizedAssets(cfg.Rotation.SupportedAssets, bridge)
+	if len(assets) == 0 {
+		return fmt.Errorf("rotation: supported-assets is empty")
+	}
+	currentAsset := strings.ToUpper(cfg.Rotation.CurrentAsset)
+	if persisted, ok, err := store.CurrentAsset(); err != nil {
+		return err
+	} else if ok {
+		currentAsset = strings.ToUpper(persisted)
+	}
+	if currentAsset == "" {
+		currentAsset = assets[0]
+	}
+	if err := store.SetCurrentAsset(currentAsset); err != nil {
+		return err
+	}
+	client := binance_connector.NewClient(exchange.APIKey, exchange.SecretKey, exchange.BaseURL)
+	baselines := map[string]rotationPair{}
+	jumps := 0
+	sleep := time.Duration(cfg.Rotation.ScoutSleepSeconds) * time.Second
+	if sleep <= 0 {
+		sleep = time.Second
+	}
+
+	fmt.Printf("Rotation scout started: current=%s bridge=%s assets=%v dry-run=%v\n", currentAsset, bridge, assets, cfg.Rotation.DryRun)
+	for {
+		prices, err := exchange.GetAllTickerPrices(client)
+		if err != nil {
+			return err
+		}
+		if len(baselines) == 0 {
+			initializeRotationBaselines(baselines, assets, bridge, prices)
+		}
+		best, ok := bestRotationCandidate(cfg, store, currentAsset, assets, bridge, baselines, prices)
+		if ok {
+			fmt.Printf("Selected rotation %s -> %s through %s (opportunity %.8f)\n", currentAsset, best.ToAsset, bridge, best.Opportunity)
+			if err := executeRotation(cfg, store, currentAsset, best.ToAsset, bridge, prices); err != nil {
+				return err
+			}
+			currentAsset = best.ToAsset
+			jumps++
+			initializeRotationBaselines(baselines, assets, bridge, prices)
+			if cfg.Rotation.MaxJumps > 0 && jumps >= cfg.Rotation.MaxJumps {
+				return nil
+			}
+		}
+		time.Sleep(sleep)
+	}
+}
+
+type rotationCandidate struct {
+	ToAsset     string
+	Opportunity float64
+}
+
+func bestRotationCandidate(cfg *config.Config, store *storage.Store, currentAsset string, assets []string, bridge string, baselines map[string]rotationPair, prices map[string]float64) (rotationCandidate, bool) {
+	fromPrice := prices[currentAsset+bridge]
+	if fromPrice <= 0 {
+		return rotationCandidate{}, false
+	}
+	defaultFee := cfg.Fees.DefaultTakerPct
+	if defaultFee <= 0 {
+		defaultFee = 0.1
+	}
+	tradeFeePct := defaultFee * 2
+	var best rotationCandidate
+	for _, asset := range assets {
+		if asset == currentAsset {
+			continue
+		}
+		toPrice := prices[asset+bridge]
+		if toPrice <= 0 {
+			continue
+		}
+		key := currentAsset + ">" + asset
+		pair, ok := baselines[key]
+		if !ok || pair.BaselineRatio <= 0 {
+			continue
+		}
+		currentRatio := fromPrice / toPrice
+		var opportunity float64
+		if cfg.Rotation.UseMargin {
+			opportunity = (1-tradeFeePct/100)*currentRatio/pair.BaselineRatio - 1 - cfg.Rotation.ScoutMarginPct/100
+		} else {
+			multiplier := cfg.Rotation.ScoutMultiplier
+			if multiplier <= 0 {
+				multiplier = 5
+			}
+			opportunity = currentRatio - (tradeFeePct/100)*multiplier*currentRatio - pair.BaselineRatio
+		}
+		selected := opportunity > 0 && opportunity > best.Opportunity
+		_ = store.AppendScout(storage.ScoutRecord{
+			FromAsset:     currentAsset,
+			ToAsset:       asset,
+			BridgeAsset:   bridge,
+			FromPrice:     fromPrice,
+			ToPrice:       toPrice,
+			BaselineRatio: pair.BaselineRatio,
+			CurrentRatio:  currentRatio,
+			Opportunity:   opportunity,
+			TradeFeePct:   tradeFeePct,
+			Selected:      selected,
+		})
+		if selected {
+			best = rotationCandidate{ToAsset: asset, Opportunity: opportunity}
+		}
+	}
+	return best, best.ToAsset != ""
+}
+
+func executeRotation(cfg *config.Config, store *storage.Store, fromAsset, toAsset, bridge string, prices map[string]float64) error {
+	if cfg.Rotation.DryRun {
+		_ = store.SetCurrentAsset(toAsset)
+		return store.AppendTrade(storage.TradeRecord{
+			Symbol: fromAsset + bridge + ">" + toAsset + bridge,
+			Side:   "ROTATE",
+			Status: "DRY_RUN",
+			Reason: "rotation-scout",
+			Mode:   "rotation",
+		})
+	}
+	if fromAsset != bridge {
+		sellSymbol := fromAsset + bridge
+		balance, err := exchange.GetBalance(fromAsset)
+		if err != nil {
+			return err
+		}
+		if balance <= 0 {
+			return fmt.Errorf("rotation: no %s balance to sell", fromAsset)
+		}
+		if _, err := TradeMarketSell(sellSymbol, balance, prices[sellSymbol], 8); err != nil {
+			return err
+		}
+		_ = store.AppendTrade(storage.TradeRecord{Symbol: sellSymbol, Side: "SELL", Status: "SUBMITTED", Quantity: balance, Price: prices[sellSymbol], Reason: "rotation-scout", Mode: "rotation"})
+	}
+	bridgeBalance, err := exchange.GetBalance(bridge)
+	if err != nil {
+		return err
+	}
+	buySymbol := toAsset + bridge
+	price := prices[buySymbol]
+	if price <= 0 {
+		return fmt.Errorf("rotation: missing price for %s", buySymbol)
+	}
+	buffer := cfg.Rotation.MinNotionalBuffer
+	if buffer <= 0 {
+		buffer = 1.01
+	}
+	qty := math.Floor((bridgeBalance/price)/buffer*1e8) / 1e8
+	if qty <= 0 {
+		return fmt.Errorf("rotation: bridge balance %.8f is too small to buy %s", bridgeBalance, toAsset)
+	}
+	if _, err := TradeMarketBuy(buySymbol, qty, price, 8); err != nil {
+		return err
+	}
+	_ = store.SetCurrentAsset(toAsset)
+	return store.AppendTrade(storage.TradeRecord{Symbol: buySymbol, Side: "BUY", Status: "SUBMITTED", Quantity: qty, Price: price, QuoteQuantity: bridgeBalance, Reason: "rotation-scout", Mode: "rotation"})
+}
+
+func initializeRotationBaselines(out map[string]rotationPair, assets []string, bridge string, prices map[string]float64) {
+	for key := range out {
+		delete(out, key)
+	}
+	for _, from := range assets {
+		fromPrice := prices[from+bridge]
+		if fromPrice <= 0 {
+			continue
+		}
+		for _, to := range assets {
+			if from == to {
+				continue
+			}
+			toPrice := prices[to+bridge]
+			if toPrice <= 0 {
+				continue
+			}
+			out[from+">"+to] = rotationPair{
+				FromAsset:     from,
+				ToAsset:       to,
+				BaselineRatio: fromPrice / toPrice,
+			}
+		}
+	}
+}
+
+func normalizedAssets(input []string, bridge string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, asset := range input {
+		asset = strings.ToUpper(strings.TrimSpace(asset))
+		if asset == "" || asset == bridge || seen[asset] {
+			continue
+		}
+		seen[asset] = true
+		out = append(out, asset)
+	}
+	return out
+}


### PR DESCRIPTION
# Summary

Adds the feature set inspired by `ccxt/binance-trade-bot`:

- multi-asset rotation scout mode through a configurable bridge asset
- managed order timeouts with partial-fill handling
- fee-aware take-profit adjustment
- persistent JSONL trade/scout/value history
- local HTTP history API
- backtest command backed by a small strategy registry

# Documentation

- Bumped CLI version to `v0.10.0`
- Updated `README.md` with new features, commands, help output, and config sections
- Extended both sample config files with persistence, fee, order-management, rotation, backtest, and API settings