### PR TITLE
Fix managed order phase transitions

### DIFF
--- a/PR-description-draft.md
+++ b/PR-description-draft.md
@@ -1,9 +1,11 @@
 # Summary
 
-Adds the feature set inspired by `ccxt/binance-trade-bot`:
+Adds the feature set inspired by `ccxt/binance-trade-bot` and fixes managed-order phase handling:
 
 - multi-asset rotation scout mode through a configurable bridge asset
 - managed order timeouts with partial-fill handling
+- explicit filled/not-filled order wait results so unfilled entries return to scanning instead of entering exit monitoring
+- exit monitoring remains active when stop-loss, trailing-stop, or take-profit orders do not fill
 - fee-aware take-profit adjustment
 - persistent JSONL trade/scout/value history
 - local HTTP history API
@@ -11,8 +13,8 @@ Adds the feature set inspired by `ccxt/binance-trade-bot`:
 
 # Documentation
 
-- Bumped CLI version to `v0.10.0`
-- Updated `README.md` with new features, commands, help output, and config sections
+- Bumped CLI version to `v0.10.1`
+- Updated `README.md` with new features, commands, help output, config sections, and managed-order behavior
 - Extended both sample config files with persistence, fee, order-management, rotation, backtest, and API settings
 
 # Validation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
 - **Rotation Scout Mode** — Scans a configured asset basket and rotates through a bridge asset when relative ratios become fee-adjusted opportunities
 - **Backtesting** — Runs registered strategy simulations over recent Binance candles before live trading
-- **Managed Orders** — Optional buy/sell timeouts with partial-fill handling for stale limit orders
+- **Managed Orders** — Optional buy/sell timeouts with partial-fill handling; unfilled entries return to scanning instead of advancing to exit monitoring
 - **Persistent History API** — Stores trade/scout history in JSONL and serves it through a small local HTTP API
 - **AI Multi-Agent System** — Concurrent analysis from OpenAI, DeepSeek, and Claude with weighted consensus; when enabled, entries require explicit AI approval at the configured confidence threshold
 - **Sentiment Analysis** — Real-time news headlines and Fear & Greed Index integrated into AI decisions
@@ -232,7 +232,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.10.0
+     v0.10.1
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.10.0",
+		Version:  "v0.10.1",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -357,7 +357,12 @@ func bearTradeLoop(
 					dash.LogInfo(fmt.Sprintf("SELL order #%d - Status: %s", getor.OrderId, getor.Status))
 				}
 
-				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Entry SELL did not fill; returning to entry scan[-]")
+					dash.SetPhase("SCANNING SELL")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				break
 			}
 			time.Sleep(refreshInterval)
@@ -424,7 +429,12 @@ func bearTradeLoop(
 						orderId := buyOrder.FieldByName("OrderId").Int()
 						dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET BUY[-] %f %s @ ~[white::b]%.*f[-] %s",
 							buyBackQty, scoin, roundPrice, price, dcoin))
-						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg)
+						if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg) {
+							dash.LogInfo("[yellow]Trailing-stop BUY did not fill; continuing buy-back monitoring[-]")
+							dash.SetPhase("MONITORING BUY-BACK")
+							time.Sleep(refreshInterval)
+							continue
+						}
 						exitType = "ts"
 						break
 					}
@@ -466,7 +476,12 @@ func bearTradeLoop(
 				orderId := buyOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 					buyBackQty, scoin, roundPrice, price, dcoin, effectiveSL))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Stop-loss BUY did not fill; continuing buy-back monitoring[-]")
+					dash.SetPhase("MONITORING BUY-BACK")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				exitType = "sl"
 				break
 			}
@@ -510,7 +525,12 @@ func bearTradeLoop(
 				orderId := buyOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[green::b]BUY[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 					buyBackQty, scoin, roundPrice, price, dcoin, roundPrice, price*buyBackQty, dcoin))
-				waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Take-profit BUY did not fill; continuing buy-back monitoring[-]")
+					dash.SetPhase("MONITORING BUY-BACK")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				exitType = "tp"
 				break
 			}

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -356,7 +356,12 @@ func bullTradeLoop(
 					dash.LogInfo(fmt.Sprintf("BUY order #%d - Status: %s", getor.OrderId, getor.Status))
 				}
 
-				waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Entry BUY did not fill; returning to entry scan[-]")
+					dash.SetPhase("SCANNING BUY")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				break
 			}
 			time.Sleep(refreshInterval)
@@ -421,7 +426,12 @@ func bullTradeLoop(
 						orderId := sellOrder.FieldByName("OrderId").Int()
 						dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET SELL[-] %f %s @ ~[white::b]%.*f[-] %s",
 							qty, scoin, roundPrice, price, dcoin))
-						waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg)
+						if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg) {
+							dash.LogInfo("[yellow]Trailing-stop SELL did not fill; continuing exit monitoring[-]")
+							dash.SetPhase("MONITORING SELL")
+							time.Sleep(refreshInterval)
+							continue
+						}
 						exitType = "ts"
 						break
 					}
@@ -462,7 +472,12 @@ func bullTradeLoop(
 				orderId := sellOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 					qty, scoin, roundPrice, price, dcoin, effectiveSL))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Stop-loss SELL did not fill; continuing exit monitoring[-]")
+					dash.SetPhase("MONITORING SELL")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				exitType = "sl"
 				break
 			}
@@ -505,7 +520,12 @@ func bullTradeLoop(
 				orderId := sellOrder.FieldByName("OrderId").Int()
 				dash.LogOrder(fmt.Sprintf("[red::b]SELL[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 					qty, scoin, roundPrice, price, dcoin, roundPrice, price*qty, dcoin))
-				waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
+				if !waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Take-profit SELL did not fill; continuing exit monitoring[-]")
+					dash.SetPhase("MONITORING SELL")
+					time.Sleep(refreshInterval)
+					continue
+				}
 				exitType = "tp"
 				break
 			}

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -573,7 +573,12 @@ func dynamicTradeLoop(
 					if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 						dash.LogInfo(fmt.Sprintf("BUY order #%d - Status: %s", getor.OrderId, getor.Status))
 					}
-					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[green::b]BUY order filled![-]", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Entry BUY did not fill; returning to entry scan[-]")
+						dash.SetPhase("SCANNING BUY")
+						time.Sleep(refreshInterval)
+						continue
+					}
 				} else {
 					dash.SetPhase("SELLING")
 					sell, err := TradeSell(symbol, qty, price, sellFactor, roundPrice)
@@ -592,7 +597,12 @@ func dynamicTradeLoop(
 					if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 						dash.LogInfo(fmt.Sprintf("SELL order #%d - Status: %s", getor.OrderId, getor.Status))
 					}
-					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL order filled![-]", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[red::b]SELL order filled![-]", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Entry SELL did not fill; returning to entry scan[-]")
+						dash.SetPhase("SCANNING SELL")
+						time.Sleep(refreshInterval)
+						continue
+					}
 				}
 				break
 			}
@@ -658,7 +668,12 @@ func dynamicTradeLoop(
 							orderId := sellOrder.FieldByName("OrderId").Int()
 							dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET SELL[-] %f %s @ ~[white::b]%.*f[-] %s",
 								qty, scoin, roundPrice, price, dcoin))
-							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg)
+							if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET SELL[-] filled!", refreshInterval, cfg) {
+								dash.LogInfo("[yellow]Trailing-stop SELL did not fill; continuing exit monitoring[-]")
+								dash.SetPhase("MONITORING SELL")
+								time.Sleep(refreshInterval)
+								continue
+							}
 							exitType = "ts"
 							break
 						}
@@ -699,7 +714,12 @@ func dynamicTradeLoop(
 					orderId := sellOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 						qty, scoin, roundPrice, price, dcoin, effectiveSL))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET SELL[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Stop-loss SELL did not fill; continuing exit monitoring[-]")
+						dash.SetPhase("MONITORING SELL")
+						time.Sleep(refreshInterval)
+						continue
+					}
 					exitType = "sl"
 					break
 				}
@@ -742,7 +762,12 @@ func dynamicTradeLoop(
 					orderId := sellOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]SELL[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 						qty, scoin, roundPrice, price, dcoin, roundPrice, price*qty, dcoin))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[red::b]SELL[-] order filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Take-profit SELL did not fill; continuing exit monitoring[-]")
+						dash.SetPhase("MONITORING SELL")
+						time.Sleep(refreshInterval)
+						continue
+					}
 					exitType = "tp"
 					break
 				}
@@ -803,7 +828,12 @@ func dynamicTradeLoop(
 							orderId := buyOrder.FieldByName("OrderId").Int()
 							dash.LogOrder(fmt.Sprintf("[fuchsia::b]TRAILING-STOP MARKET BUY[-] %f %s @ ~[white::b]%.*f[-] %s",
 								buyBackQty, scoin, roundPrice, price, dcoin))
-							waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg)
+							if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]TRAILING-STOP MARKET BUY[-] filled!", refreshInterval, cfg) {
+								dash.LogInfo("[yellow]Trailing-stop BUY did not fill; continuing buy-back monitoring[-]")
+								dash.SetPhase("MONITORING BUY-BACK")
+								time.Sleep(refreshInterval)
+								continue
+							}
 							exitType = "ts"
 							break
 						}
@@ -845,7 +875,12 @@ func dynamicTradeLoop(
 					orderId := buyOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[red::b]STOP-LOSS MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (SL=%.2f%%)",
 						buyBackQty, scoin, roundPrice, price, dcoin, effectiveSL))
-					waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[red::b]STOP-LOSS MARKET BUY[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Stop-loss BUY did not fill; continuing buy-back monitoring[-]")
+						dash.SetPhase("MONITORING BUY-BACK")
+						time.Sleep(refreshInterval)
+						continue
+					}
 					exitType = "sl"
 					break
 				}
@@ -889,7 +924,12 @@ func dynamicTradeLoop(
 					orderId := buyOrder.FieldByName("OrderId").Int()
 					dash.LogOrder(fmt.Sprintf("[green::b]BUY[-] %f %s @ [white::b]%.*f[-] %s = %.*f %s",
 						buyBackQty, scoin, roundPrice, price, dcoin, roundPrice, price*buyBackQty, dcoin))
-					waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg)
+					if !waitOrderFilled(dash, ticker, orderId, "[green::b]BUY[-] order filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Take-profit BUY did not fill; continuing buy-back monitoring[-]")
+						dash.SetPhase("MONITORING BUY-BACK")
+						time.Sleep(refreshInterval)
+						continue
+					}
 					exitType = "tp"
 					break
 				}

--- a/strategy/helpers.go
+++ b/strategy/helpers.go
@@ -200,7 +200,10 @@ func logEntryConditions(dash *tui.Dashboard, mode string, conditions []entryCond
 }
 
 // waitOrderFilled polls until an order is filled, logging the result.
-func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMsg string, interval time.Duration, cfgs ...*config.Config) {
+// It returns true only when Binance reports FILLED. Timeout, cancelation,
+// rejection, expiration, or wait errors return false so callers can avoid
+// advancing into the next trade phase without an actual position.
+func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMsg string, interval time.Duration, cfgs ...*config.Config) bool {
 	var cfg *config.Config
 	if len(cfgs) > 0 {
 		cfg = cfgs[0]
@@ -231,7 +234,7 @@ func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMs
 		result, err := exchange.WaitForManagedOrder(ticker, orderId, side, timeout, pollInterval, partialFillAction)
 		if err != nil {
 			dash.LogError(fmt.Sprintf("Order #%d wait failed: %v", orderId, err))
-			return
+			return false
 		}
 		if result.Order != nil {
 			price, _ := strconv.ParseFloat(result.Order.Price, 64)
@@ -249,7 +252,7 @@ func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMs
 			})
 			if result.Order.Status == "FILLED" {
 				dash.LogOrder(filledMsg)
-				return
+				return true
 			}
 		}
 		if result.TimedOut {
@@ -257,18 +260,18 @@ func waitOrderFilled(dash *tui.Dashboard, ticker string, orderId int64, filledMs
 			if result.PartialHandled {
 				dash.LogInfo(fmt.Sprintf("[yellow]Partial fill on order #%d was reversed with a market order[-]", orderId))
 			}
-			return
+			return false
 		}
 		if result.Order != nil {
 			dash.LogInfo(fmt.Sprintf("[yellow]Order #%d ended with status %s[-]", orderId, result.Order.Status))
 		}
-		return
+		return false
 	}
 	for {
 		if getor, err := exchange.GetOrder(ticker, orderId); err == nil {
 			if getor.Status == "FILLED" {
 				dash.LogOrder(filledMsg)
-				return
+				return true
 			}
 		}
 		time.Sleep(interval)


### PR DESCRIPTION
# Summary

Fixes managed-order phase transitions after limit order timeouts or other non-filled terminal states.

Before this change, a timed-out entry order could still advance the strategy into the exit phase. In bear auto-trade, that meant the TUI could show `MONITORING BUY-BACK` even though the opening sell order had been canceled and no short-side position had actually been established. The same issue existed in the standalone `bull-trade` and `bear-trade` entry paths.

# Changes

- Make `waitOrderFilled` return `true` only when Binance reports the order as `FILLED`.
- Return to entry scanning when an opening BUY or SELL order times out, is canceled, expires, is rejected, or fails while waiting.
- Keep exit monitoring active when take-profit, stop-loss, or trailing-stop exit orders do not fill.
- Update managed-order documentation to clarify that unfilled entries do not advance to exit monitoring.
- Bump the CLI version to `v0.10.1`.

# Risk / Behavior Notes

This changes behavior only after an order wait finishes without a fill. Successful fills keep the existing flow. If an entry order times out, the bot now logs the failure and resumes scanning instead of treating the configured entry price as an active position.

# Validation

- `go test -v ./...`
- `go build ./...`