### PR TITLE
fix: make auto trade balance aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Features
 
-- **Auto Trade** — Automatically detects market tendency and switches between bull/bear strategies per operation; supports forced strategy mode to wait for a matching tendency
+- **Auto Trade** — Automatically detects market tendency and switches between bull/bear strategies per operation; supports forced strategy mode and waits when the account cannot fund the detected side
 - **Bull Trade** — Buy-low-sell-high strategy for uptrending markets
 - **Bear Trade** — Sell-high-buy-low strategy for downtrending markets
 - **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system; no longer requires all signals simultaneously
@@ -233,7 +233,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.10.2
+     v0.10.3
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -339,7 +339,7 @@ fees:
   buffer-pct: 0.05
 ```
 
-The bot writes trade/scout history to `data-dir`. Managed order timeouts cancel stale limit orders; `partial-fill-action: "reverse"` attempts a market order in the opposite direction for partial timeout fills. Before any limit or market order is submitted, the bot queries Binance spot account balances and verifies that the required base or quote asset is available as free balance. Fee-aware mode subtracts estimated round-trip taker fees and `buffer-pct` from take-profit decisions.
+The bot writes trade/scout history to `data-dir`. Managed order timeouts cancel stale limit orders; `partial-fill-action: "reverse"` attempts a market order in the opposite direction for partial timeout fills. Before any limit or market order is submitted, the bot queries Binance spot account balances and verifies that the required base or quote asset is available as free balance. In `auto-trade`, this balance check also gates mode selection: a detected bull tendency requires enough quote asset to buy, and a detected bear tendency requires enough base asset to sell. Fee-aware mode subtracts estimated round-trip taker fees and `buffer-pct` from take-profit decisions.
 
 ### Indicators Configuration
 
@@ -598,8 +598,8 @@ The `auto-trade` command removes the need to manually choose between bull and be
    - `bear`: Forces sell-first operations — the bot waits until tendency is "down" before entering. Ideal when you hold the base asset and want to sell first.
 2. **Tendency Detection**: At the start of each operation, the bot fetches historical prices on the configured `tendency.interval` and compares DEMA to EMA. If DEMA > EMA the tendency is "up" (bull); otherwise "down" (bear).
 3. **Waiting for Match**: When a strategy is forced (`bull` or `bear`), the bot continuously monitors tendency and only proceeds when it matches the required direction. The TUI shows the mode with "(waiting)" until tendency aligns.
-4. **Mode Selection**: Based on the detected/matched tendency, the bot switches to the appropriate strategy — bull (buy low, sell high) or bear (sell high, buy back low).
-5. **Live Re-detection**: During entry scanning in `auto` mode, if the tendency flips, the bot immediately adapts and switches to the opposite mode. In forced strategy mode, a tendency flip causes the bot to return to waiting.
+4. **Balance-Aware Mode Selection**: Based on the detected/matched tendency, the bot switches to the appropriate strategy only if the account can fund that entry. Bull mode requires enough free quote asset for the buy, such as USDT for `XRP/USDT`; bear mode requires enough free base asset for the sell, such as XRP for `XRP/USDT`.
+5. **Live Re-detection**: During entry scanning in `auto` mode, if the tendency flips, the bot adapts only when the account can fund the new side. If the detected side cannot be funded, the bot keeps monitoring instead of exiting. In forced strategy mode, a tendency flip causes the bot to return to waiting.
 6. **Entry & Exit**: Once a mode is selected, the exact same entry conditions (classic or scalp scoring) and exit mechanisms (trailing stop, stop-loss, take-profit, AI confirmation) apply as in the standalone `bull-trade` or `bear-trade` commands.
 7. **Per-Operation Adaptation**: After each completed operation (entry + exit), the bot re-detects tendency before the next one.
 
@@ -607,6 +607,7 @@ The `auto-trade` command removes the need to manually choose between bull and be
 
 The TUI header dynamically shows the current mode:
 - `BULL (waiting)` or `BEAR (waiting)` when a forced strategy is waiting for matching tendency
+- `BULL (waiting balance)` or `BEAR (waiting balance)` when tendency matches but the account lacks the free asset required for that entry
 - `AUTO MODE` in cyan at startup (when strategy is auto)
 - Switches to `BULL MODE` (green) or `BEAR MODE` (red) once tendency is detected/matched
 - Updates in real-time if tendency flips during scanning

--- a/exchange/order.go
+++ b/exchange/order.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -28,6 +29,26 @@ type ManagedOrderResult struct {
 	ExecutedQty        float64
 	CumulativeQuoteQty float64
 	PartialHandled     bool
+}
+
+var ErrInsufficientBalance = errors.New("insufficient balance")
+
+type OrderBalanceCheck struct {
+	Symbol    string
+	Side      string
+	Asset     string
+	Quantity  float64
+	Price     float64
+	Required  float64
+	Available float64
+}
+
+func (c *OrderBalanceCheck) Sufficient() bool {
+	return c.Available+1e-12 >= c.Required
+}
+
+func IsInsufficientBalance(err error) bool {
+	return errors.Is(err, ErrInsufficientBalance)
 }
 
 // GetSymbolFilters fetches MIN_NOTIONAL and LOT_SIZE filters from Binance exchange info.
@@ -88,22 +109,42 @@ func requiredBalance(side string, quantity, price float64, filters *SymbolFilter
 	}
 }
 
-func EnsureSufficientBalance(symbol, side string, quantity, price float64) error {
+func CheckOrderBalance(symbol, side string, quantity, price float64) (*OrderBalanceCheck, error) {
 	filters, err := GetSymbolFilters(symbol)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	return CheckOrderBalanceWithFilters(symbol, side, quantity, price, filters)
+}
+
+func CheckOrderBalanceWithFilters(symbol, side string, quantity, price float64, filters *SymbolFilters) (*OrderBalanceCheck, error) {
 	asset, required, err := requiredBalance(side, quantity, price, filters)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	free, err := GetBalance(asset)
 	if err != nil {
+		return nil, err
+	}
+	return &OrderBalanceCheck{
+		Symbol:    symbol,
+		Side:      side,
+		Asset:     asset,
+		Quantity:  quantity,
+		Price:     price,
+		Required:  required,
+		Available: free,
+	}, nil
+}
+
+func EnsureSufficientBalance(symbol, side string, quantity, price float64) error {
+	check, err := CheckOrderBalance(symbol, side, quantity, price)
+	if err != nil {
 		return err
 	}
-	if free+1e-12 < required {
-		return fmt.Errorf("balance: insufficient %s balance for %s %s order: need %.8f, available %.8f",
-			asset, symbol, side, required, free)
+	if !check.Sufficient() {
+		return fmt.Errorf("%w: insufficient %s balance for %s %s order: need %.8f, available %.8f",
+			ErrInsufficientBalance, check.Asset, symbol, side, check.Required, check.Available)
 	}
 	return nil
 }

--- a/exchange/order_test.go
+++ b/exchange/order_test.go
@@ -43,3 +43,23 @@ func TestRequiredBalanceRejectsBuyWithoutPrice(t *testing.T) {
 		t.Fatal("expected BUY without price to fail")
 	}
 }
+
+func TestOrderBalanceCheckSufficientAllowsTinyFloatDrift(t *testing.T) {
+	check := &OrderBalanceCheck{
+		Required:  10,
+		Available: 10 - 5e-13,
+	}
+	if !check.Sufficient() {
+		t.Fatal("expected tiny float drift to still be sufficient")
+	}
+}
+
+func TestOrderBalanceCheckSufficientRejectsShortBalance(t *testing.T) {
+	check := &OrderBalanceCheck{
+		Required:  10,
+		Available: 9.99,
+	}
+	if check.Sufficient() {
+		t.Fatal("expected short balance to be insufficient")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.10.2",
+		Version:  "v0.10.3",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -132,6 +132,39 @@ func DynamicTrade(
 	}
 }
 
+func dynamicEntryBalanceCheck(ticker string, isBull bool, qty, price, buyFactor, sellFactor float64, roundPrice, roundAmount uint) (*exchange.OrderBalanceCheck, error) {
+	side := "BUY"
+	entryPrice := indicator.RoundFloat(price*buyFactor, roundPrice)
+	if !isBull {
+		side = "SELL"
+		entryPrice = indicator.RoundFloat(price*sellFactor, roundPrice)
+	}
+	filters, err := exchange.GetSymbolFilters(ticker)
+	if err != nil {
+		return nil, err
+	}
+	adjQty, _ := exchange.AdjustQuantity(qty, entryPrice, filters, roundAmount)
+	return exchange.CheckOrderBalanceWithFilters(ticker, side, adjQty, entryPrice, filters)
+}
+
+func dynamicEntryBalanceAvailable(dash *tui.Dashboard, ticker string, isBull bool, qty, price, buyFactor, sellFactor float64, roundPrice, roundAmount uint) bool {
+	check, err := dynamicEntryBalanceCheck(ticker, isBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount)
+	if err != nil {
+		dash.LogError(fmt.Sprintf("Entry balance check failed: %v", err))
+		return false
+	}
+	if check.Sufficient() {
+		return true
+	}
+	mode := "BULL"
+	if !isBull {
+		mode = "BEAR"
+	}
+	dash.LogInfo(fmt.Sprintf("[yellow]%s entry skipped[-] — %s %s needs %.8f %s, available %.8f; waiting for a compatible tendency",
+		mode, check.Symbol, check.Side, check.Required, check.Asset, check.Available))
+	return false
+}
+
 func dynamicTradeLoop(
 	dash *tui.Dashboard,
 	client *binance_connector.Client,
@@ -149,7 +182,8 @@ func dynamicTradeLoop(
 	var consecutiveSL int
 	takeProfit = feeAdjustedTakeProfit(symbol, cfg, takeProfit, dash)
 
-	for range max_ops {
+operationLoop:
+	for operation <= int(max_ops) {
 		dash.SetOperation(operation)
 		qty = indicator.RoundFloat(qty, roundAmount)
 
@@ -159,12 +193,14 @@ func dynamicTradeLoop(
 		var isBull bool
 
 		for {
+			var latestPrice float64
 			// Fetch OHLCV so we can update Price & Indicators panels while waiting
 			ohlcv, ohlcvErr := exchange.GetHistoricalOHLCV(client, ticker, interval, period)
 			if ohlcvErr != nil {
 				dash.LogError(fmt.Sprintf("OHLCV fetch: %v", ohlcvErr))
 			} else if len(ohlcv.Closes) >= 2 {
 				price := ohlcv.Closes[len(ohlcv.Closes)-1]
+				latestPrice = price
 				prevPrice := ohlcv.Closes[len(ohlcv.Closes)-2]
 				dash.UpdatePrice(price, prevPrice, roundPrice)
 
@@ -211,6 +247,14 @@ func dynamicTradeLoop(
 				time.Sleep(refreshInterval)
 				continue
 			}
+			if latestPrice <= 0 {
+				latestPrice, err = exchange.GetPrice(client, ticker)
+				if err != nil {
+					dash.LogError(fmt.Sprintf("Entry balance price check: %v", err))
+					time.Sleep(refreshInterval)
+					continue
+				}
+			}
 
 			// When a strategy is forced, wait for tendency to match
 			if strategy == "bull" && tendency != "up" {
@@ -222,6 +266,16 @@ func dynamicTradeLoop(
 			if strategy == "bear" && tendency != "down" {
 				dash.SetTradeMode("BEAR (waiting)")
 				dash.LogInfo(fmt.Sprintf("[yellow]Tendency is %s[-] — waiting for [red]DOWN[-] tendency to match BEAR strategy", tendency))
+				time.Sleep(refreshInterval)
+				continue
+			}
+			candidateBull := tendency == "up"
+			if !dynamicEntryBalanceAvailable(dash, ticker, candidateBull, qty, latestPrice, buyFactor, sellFactor, roundPrice, roundAmount) {
+				if candidateBull {
+					dash.SetTradeMode("BULL (waiting balance)")
+				} else {
+					dash.SetTradeMode("BEAR (waiting balance)")
+				}
 				time.Sleep(refreshInterval)
 				continue
 			}
@@ -270,7 +324,12 @@ func dynamicTradeLoop(
 				if strategy == "auto" {
 					// auto mode: switch to the new tendency
 					dash.LogInfo(fmt.Sprintf("[yellow]Tendency flipped to %s during scanning — re-detecting[-]", tendency))
-					isBull = tendency == "up"
+					nextBull := tendency == "up"
+					if !dynamicEntryBalanceAvailable(dash, ticker, nextBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount) {
+						time.Sleep(refreshInterval)
+						continue operationLoop
+					}
+					isBull = nextBull
 					if isBull {
 						dash.SetTradeMode("BULL")
 						dash.SetPhase("SCANNING BUY")
@@ -281,7 +340,8 @@ func dynamicTradeLoop(
 				} else {
 					// forced strategy: tendency no longer matches, go back to waiting
 					dash.LogInfo(fmt.Sprintf("[yellow]Tendency flipped to %s — no longer matches %s strategy, returning to wait[-]", tendency, strings.ToUpper(strategy)))
-					break
+					time.Sleep(refreshInterval)
+					continue operationLoop
 				}
 			}
 
@@ -555,10 +615,19 @@ func dynamicTradeLoop(
 			}
 
 			if shouldEnter {
+				if !dynamicEntryBalanceAvailable(dash, ticker, isBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount) {
+					time.Sleep(refreshInterval)
+					continue operationLoop
+				}
 				if isBull {
 					dash.SetPhase("BUYING")
 					buy, err := TradeBuy(symbol, qty, price, buyFactor, roundPrice)
 					if err != nil {
+						if exchange.IsInsufficientBalance(err) {
+							dash.LogError(fmt.Sprintf("BUY order skipped: %v", err))
+							time.Sleep(refreshInterval)
+							continue operationLoop
+						}
 						dash.LogError(fmt.Sprintf("BUY order failed: %v", err))
 						return
 					}
@@ -583,6 +652,11 @@ func dynamicTradeLoop(
 					dash.SetPhase("SELLING")
 					sell, err := TradeSell(symbol, qty, price, sellFactor, roundPrice)
 					if err != nil {
+						if exchange.IsInsufficientBalance(err) {
+							dash.LogError(fmt.Sprintf("SELL order skipped: %v", err))
+							time.Sleep(refreshInterval)
+							continue operationLoop
+						}
 						dash.LogError(fmt.Sprintf("SELL order failed: %v", err))
 						return
 					}


### PR DESCRIPTION
# Summary

Makes `auto-trade` balance-aware before it selects or switches entry modes. When a detected bull tendency cannot be funded with the quote asset, or a detected bear tendency cannot be funded with the base asset, the bot keeps monitoring instead of attempting an order or exiting the trading loop.

# Changes

- Added reusable order balance check details and an `ErrInsufficientBalance` sentinel in the exchange layer.
- Added auto-trade entry balance checks before initial mode selection.
- Added balance-aware handling when tendency flips during auto-trade entry scanning.
- Prevented entry-scan backouts from falling through into exit monitoring without a filled entry.
- Kept insufficient-balance order races non-fatal by returning to monitoring.
- Bumped the CLI version to `v0.10.3`.
- Updated README feature, help, order-management, and auto-trade behavior documentation.

# Testing

- `go test -v ./...`
- `go build ./...`