### PR TITLE
refactor(config): remove redundant tendency.direction field

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,6 @@ historical-prices:
 
 tendency:
   interval: "3m"        # interval for tendency calculation
-  direction: "up"       # expected direction for bull-trade
 
 indicators:
   rsi:
@@ -410,7 +409,7 @@ scalp-mode:
 |---|--------|-------------------|
 | 1 | RSI | Below upper limit |
 | 2 | MACD | MACD line above signal line |
-| 3 | Tendency | Matches configured direction |
+| 3 | Tendency | DEMA above EMA ("up") |
 | 4 | Bollinger | DEMA closer to lower band than upper band |
 | 5 | ADX | Above configured threshold |
 | 6 | Volume | Current volume above its moving average |
@@ -536,7 +535,7 @@ In **classic mode**, the bot places a buy order when **all** of the following co
 
 1. **RSI**: Value is below the configured `upper-limit` (default 70), indicating the market is not overbought.
 2. **MACD Crossover**: The MACD line crosses above the Signal line (classic) or is above the Signal line (scalp), suggesting upward momentum.
-3. **Tendency Confirmation**: The trend direction matches the configured direction (DEMA above EMA = "up").
+3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
 6. **Volume Confirmation** *(if configured)*: Current volume exceeds its moving average, avoiding false breakouts.
@@ -612,7 +611,7 @@ The TUI header dynamically shows the current mode:
 - Switches to `BULL MODE` (green) or `BEAR MODE` (red) once tendency is detected/matched
 - Updates in real-time if tendency flips during scanning
 
-> **Tip**: The `auto-trade` command uses the same config file and flags as `bull-trade` / `bear-trade`. The `tendency.direction` config field is ignored — the bot determines direction automatically.
+> **Tip**: The `auto-trade` command uses the same config file and flags as `bull-trade` / `bear-trade`. The bot determines direction automatically from the live tendency.
 
 ---
 

--- a/config/README.md
+++ b/config/README.md
@@ -82,14 +82,12 @@ Controls market direction detection and the higher-timeframe trend gate.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `interval` | string | - | Candlestick interval used to determine the current market tendency (e.g., `"3m"`, `"5m"`). |
-| `direction` | string | - | Expected market direction: `"up"` or `"down"`. Used by forced-strategy modes to wait for matching tendency. |
 | `htf-enabled` | bool | false | When `true`, enables the Higher-Timeframe (HTF) trend gate that blocks entries when the longer timeframe opposes the trade direction. |
 | `htf-interval` | string | - | The interval for the HTF tendency check (e.g., `"15m"`, `"1h"`). Should be higher than the trading `interval`. |
 
 ```yaml
 tendency:
   interval: "3m"
-  direction: "up"
   htf-enabled: false
   htf-interval: "15m"
 ```
@@ -337,7 +335,6 @@ refresh-interval: 10
 
 tendency:
   interval: "1m"
-  direction: "up"
   htf-enabled: true
   htf-interval: "5m"
 
@@ -425,7 +422,6 @@ refresh-interval: 30
 
 tendency:
   interval: "15m"
-  direction: "up"
   htf-enabled: true
   htf-interval: "1h"
 
@@ -503,7 +499,6 @@ refresh-interval: 60
 
 tendency:
   interval: "1h"
-  direction: "up"
   htf-enabled: true
   htf-interval: "4h"
 

--- a/config/file.go
+++ b/config/file.go
@@ -27,7 +27,6 @@ type Config struct {
 	} `yaml:"fees"`
 	Tendency struct {
 		Interval    string `yaml:"interval"`
-		Direction   string `yaml:"direction"`
 		HTFEnabled  bool   `yaml:"htf-enabled"`  // enable higher-timeframe trend gate
 		HTFInterval string `yaml:"htf-interval"` // e.g. "5m", "15m" — blocks entry if HTF trend opposes trade direction
 	} `yaml:"tendency"`

--- a/config/validation.go
+++ b/config/validation.go
@@ -47,9 +47,6 @@ func (c *Config) Validate() []error {
 	}
 
 	errs = appendInterval(errs, "tendency.interval", c.Tendency.Interval)
-	if c.Tendency.Direction != "up" && c.Tendency.Direction != "down" {
-		errs = append(errs, fmt.Errorf("tendency.direction must be either \"up\" or \"down\""))
-	}
 	if c.Tendency.HTFEnabled {
 		errs = appendInterval(errs, "tendency.htf-interval", c.Tendency.HTFInterval)
 	}

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -26,7 +26,6 @@ func TestValidateReportsMultipleIssues(t *testing.T) {
 	}
 
 	cfg.HistoricalPrices.Interval = "2m"
-	cfg.Tendency.Direction = "sideways"
 	cfg.Indicators.Rsi.LowerLimit = 80
 	cfg.Indicators.Macd.FastLength = 26
 	cfg.Indicators.Macd.SlowLength = 12
@@ -39,7 +38,6 @@ func TestValidateReportsMultipleIssues(t *testing.T) {
 
 	want := []string{
 		"historical-prices.interval must be a valid Binance interval",
-		"tendency.direction must be either \"up\" or \"down\"",
 		"indicators.rsi limits must satisfy lower-limit < middle-limit < upper-limit",
 		"indicators.macd.fast-length must be less than slow-length",
 		"ai.min-confidence must be between 0 and 1",

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.10.3",
+		Version:  "v0.11.0",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -23,8 +23,7 @@ fees:
 
 tendency:
   interval: "3m"
-  direction: "up"
-  htf-enabled: false     # higher-timeframe trend gate (blocks entry if HTF trend opposes direction)
+  htf-enabled: false     # higher-timeframe trend gate (blocks bull entry when HTF trend is down, bear entry when HTF trend is up)
   htf-interval: "15m"   # interval used for higher-timeframe tendency check
 indicators:
   rsi:

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -28,7 +28,6 @@ fees:
 
 tendency:
   interval: "1m"        # fast tendency on 1m (was 3m)
-  direction: "up"
   htf-enabled: true      # block entries when 5m trend opposes direction
   htf-interval: "5m"    # higher-timeframe gate for scalp mode
 

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -237,7 +237,7 @@ func bullTradeLoop(
 				htfTendency, htfErr := exchange.GetTendency(client, ticker, cfg.Tendency.HTFInterval, period)
 				if htfErr != nil {
 					dash.LogError(fmt.Sprintf("HTF Tendency: %v", htfErr))
-				} else if htfTendency != cfg.Tendency.Direction {
+				} else if htfTendency != "up" {
 					dash.LogInfo(fmt.Sprintf("[red]HTF GATE[-] %s trend is [red]%s[-] on %s — skipping BULL entry",
 						symbol, htfTendency, cfg.Tendency.HTFInterval))
 					time.Sleep(refreshInterval)
@@ -269,12 +269,12 @@ func bullTradeLoop(
 					Met:  macdOk,
 				})
 
-				tendOk := tendency == cfg.Tendency.Direction
+				tendOk := tendency == "up"
 				if tendOk {
 					score++
 				}
 				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Tendency %s = %s", tendency, cfg.Tendency.Direction),
+					Name: fmt.Sprintf("Tendency %s = up", tendency),
 					Met:  tendOk,
 				})
 
@@ -318,7 +318,7 @@ func bullTradeLoop(
 				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit)
 				macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
 					macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
-				tendOk := tendency == cfg.Tendency.Direction
+				tendOk := tendency == "up"
 				bbOk := distanceToLower < distanceToUpper
 
 				shouldBuy = rsiOk && macdCrossOk && tendOk && bbOk &&
@@ -328,7 +328,7 @@ func bullTradeLoop(
 					conditions := []entryCondition{
 						{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
 						{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
-						{Name: fmt.Sprintf("Tendency %s = %s", tendency, cfg.Tendency.Direction), Met: tendOk},
+						{Name: fmt.Sprintf("Tendency %s = up", tendency), Met: tendOk},
 						{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},
 						{Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold), Met: adxStrong},
 						{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume), Met: volumeConfirmed},

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -13,20 +13,20 @@ import (
 
 // Dashboard manages the multi-panel terminal UI for the trading bot.
 type Dashboard struct {
-	app          *tview.Application
-	header       *tview.TextView
-	pricePanel   *tview.TextView
-	indPanel     *tview.TextView
-	paramsPanel  *tview.TextView
-	aiPanel      *tview.TextView
-	ordersPanel  *tview.TextView
+	app         *tview.Application
+	header      *tview.TextView
+	pricePanel  *tview.TextView
+	indPanel    *tview.TextView
+	paramsPanel *tview.TextView
+	aiPanel     *tview.TextView
+	ordersPanel *tview.TextView
 
-	mainLayout   *tview.Flex
+	mainLayout *tview.Flex
 
-	tradeMode    string
-	symbol       string
-	operation    int
-	phase        string // "SCANNING", "BUYING", "SELLING", etc.
+	tradeMode string
+	symbol    string
+	operation int
+	phase     string // "SCANNING", "BUYING", "SELLING", etc.
 
 	// Countdown state
 	mu            sync.Mutex
@@ -288,7 +288,7 @@ func (d *Dashboard) showConfig(mainLayout *tview.Flex) {
 		b.WriteString(fmt.Sprintf("  Refresh: [white]%ds[-]\n\n", c.RefreshInterval))
 
 		b.WriteString("[yellow::b]Tendency[-]\n")
-		b.WriteString(fmt.Sprintf("  Direction: [white]%s[-]  Interval: [white]%s[-]\n", c.Tendency.Direction, c.Tendency.Interval))
+		b.WriteString(fmt.Sprintf("  Interval: [white]%s[-]\n", c.Tendency.Interval))
 		b.WriteString(fmt.Sprintf("  HTF Enabled: [white]%v[-]  HTF Interval: [white]%s[-]\n\n", c.Tendency.HTFEnabled, c.Tendency.HTFInterval))
 
 		b.WriteString("[yellow::b]Indicators[-]\n")
@@ -577,13 +577,13 @@ type AgentResult struct {
 
 // AIConsensusData holds the full AI consensus for display.
 type AIConsensusData struct {
-	FinalSignal   string
-	AvgConfidence float64
-	BuyScore      float64
-	SellScore     float64
-	HoldScore     float64
-	Agents        []AgentResult
-	FearGreed     int
+	FinalSignal    string
+	AvgConfidence  float64
+	BuyScore       float64
+	SellScore      float64
+	HoldScore      float64
+	Agents         []AgentResult
+	FearGreed      int
 	FearGreedLabel string
 }
 


### PR DESCRIPTION
The tendency.direction config was only meaningfully read by bull-trade, where any value other than "up" was nonsensical. bear-trade already hardcoded "down", and auto-trade explicitly ignored the field.

- Drop Tendency.Direction from Config struct and validation.
- Hardcode "up" as the required tendency in bull-trade (classic, scalp, and HTF gate paths) to mirror bear-trade.
- Remove Direction line from the TUI config panel.
- Strip direction key from sample configs and update README/config docs.
- Bump CLI version to v0.11.0.