### PR TITLE
feat: order retry on insufficient balance, log throttle, configurable…

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.11.1
+     v0.13.0
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -344,6 +344,7 @@ fees:
   enabled: true
   default-taker-pct: 0.1
   buffer-pct: 0.05
+  buy-back-buffer-pct: 0.2
 ```
 
 | Field | Type | Sample | Description |
@@ -355,8 +356,9 @@ fees:
 | `fees.enabled` | bool | `true` | Enables fee-aware take-profit decisions. |
 | `fees.default-taker-pct` | float | `0.1` | Fallback taker fee percent when live fee lookup is unavailable. |
 | `fees.buffer-pct` | float | `0.05` | Extra safety buffer subtracted from take-profit decisions. |
+| `fees.buy-back-buffer-pct` | float | `0.2` | Percent withheld when sizing round-trip orders (buy-back, sell-back) and when scaling down orders after an insufficient-balance retry. Lower this when running with BNB fee discounts. Defaults to `0.2` when unset. |
 
-Before submitting any order, the bot checks Binance spot free balances for the required base or quote asset. Fee-aware mode subtracts estimated round-trip taker fees and `buffer-pct` from take-profit decisions.
+Before submitting any order, the bot checks Binance spot free balances for the required base or quote asset. Fee-aware mode subtracts estimated round-trip taker fees and `buffer-pct` from take-profit decisions. When an order is rejected with insufficient balance, the bot automatically retries once with the quantity reduced to fit the available balance (minus `buy-back-buffer-pct`).
 
 ### Tendency And Indicators
 

--- a/config/fees.go
+++ b/config/fees.go
@@ -1,0 +1,19 @@
+package config
+
+// DefaultBuyBackBufferPct is the safety buffer (in percent) used to scale
+// down buy-back / round-trip order quantities so the wallet's remaining
+// balance — after Binance trading fees — is enough to cover the order.
+//
+// 0.2% covers a 0.1% taker commission per leg plus a small margin for
+// price drift between the price-quote and the order being accepted.
+const DefaultBuyBackBufferPct = 0.2
+
+// BuyBackBuffer returns the configured fees.buy-back-buffer-pct or the
+// default (0.2%) when the user hasn't set it (zero value). Negative
+// values are clamped to 0 by Validate.
+func (c *Config) BuyBackBuffer() float64 {
+	if c.Fees.BuyBackBufferPct <= 0 {
+		return DefaultBuyBackBufferPct
+	}
+	return c.Fees.BuyBackBufferPct
+}

--- a/config/file.go
+++ b/config/file.go
@@ -21,9 +21,10 @@ type Config struct {
 		PollIntervalSecs   int    `yaml:"poll-interval-secs"`
 	} `yaml:"order-management"`
 	Fees struct {
-		Enabled         bool    `yaml:"enabled"`
-		DefaultTakerPct float64 `yaml:"default-taker-pct"`
-		BufferPct       float64 `yaml:"buffer-pct"`
+		Enabled          bool    `yaml:"enabled"`
+		DefaultTakerPct  float64 `yaml:"default-taker-pct"`
+		BufferPct        float64 `yaml:"buffer-pct"`
+		BuyBackBufferPct float64 `yaml:"buy-back-buffer-pct"`
 	} `yaml:"fees"`
 	Tendency struct {
 		Interval       string `yaml:"interval"`

--- a/config/validation.go
+++ b/config/validation.go
@@ -45,6 +45,9 @@ func (c *Config) Validate() []error {
 	if c.Fees.BufferPct < 0 {
 		errs = append(errs, fmt.Errorf("fees.buffer-pct must be greater than or equal to 0"))
 	}
+	if c.Fees.BuyBackBufferPct < 0 {
+		errs = append(errs, fmt.Errorf("fees.buy-back-buffer-pct must be greater than or equal to 0"))
+	}
 
 	errs = appendInterval(errs, "tendency.interval", c.Tendency.Interval)
 	if c.Tendency.Period < 0 {

--- a/exchange/order.go
+++ b/exchange/order.go
@@ -174,6 +174,29 @@ func AdjustQuantity(qty, price float64, filters *SymbolFilters, roundPrecision u
 	return qty, adjusted
 }
 
+// AdjustQuantityDown truncates the quantity down to the largest value that
+// still meets LOT_SIZE. Unlike AdjustQuantity it never increases the
+// quantity — making it suitable for sizing an order to fit a fixed
+// available balance. It returns 0 when the truncated quantity violates
+// MIN_NOTIONAL or MIN_QTY (i.e. the balance is too small to place any
+// valid order on this symbol).
+func AdjustQuantityDown(qty, price float64, filters *SymbolFilters, roundPrecision uint) float64 {
+	if qty <= 0 {
+		return 0
+	}
+	if filters.StepSize > 0 {
+		qty = math.Floor(qty/filters.StepSize) * filters.StepSize
+	}
+	qty = indicator.RoundFloat(qty, roundPrecision)
+	if filters.MinQty > 0 && qty < filters.MinQty {
+		return 0
+	}
+	if filters.MinNotional > 0 && price > 0 && qty*price < filters.MinNotional {
+		return 0
+	}
+	return qty
+}
+
 // Orders fee = 0.01% (* 0.0001)
 
 func GetAllOrders(symbol string) {

--- a/main.go
+++ b/main.go
@@ -10,12 +10,13 @@ import (
 	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/server"
 	"github.com/wferreirauy/binance-bot/strategy"
+	"github.com/wferreirauy/binance-bot/tui"
 )
 
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.12.1",
+		Version:  "v0.13.0",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{
@@ -316,6 +317,7 @@ func main() {
 		},
 	}
 
+	tui.Version = app.Version
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -20,6 +20,7 @@ fees:
   enabled: true
   default-taker-pct: 0.1      # fallback taker fee percent when Binance fee lookup is unavailable
   buffer-pct: 0.05            # extra target buffer subtracted from take-profit decisions
+  buy-back-buffer-pct: 0.2    # percent withheld when sizing round-trip orders & retrying after insufficient balance (default 0.2)
 
 tendency:
   interval: "3m"

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -25,6 +25,7 @@ fees:
   enabled: true
   default-taker-pct: 0.1
   buffer-pct: 0.05
+  buy-back-buffer-pct: 0.2
 
 tendency:
   interval: "1m"        # fast tendency on 1m (was 3m)

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -43,6 +43,7 @@ func BearTrade(
 	if cfg.BaseURL != "" {
 		exchange.BaseURL = cfg.BaseURL
 	}
+	SetBuyBackBufferPct(cfg.BuyBackBuffer())
 	period := cfg.HistoricalPrices.Period
 	interval := cfg.HistoricalPrices.Interval
 
@@ -421,7 +422,12 @@ func bearTradeLoop(
 						dash.SetPhase("TRAILING STOP")
 						dash.LogInfo(fmt.Sprintf("[fuchsia]Trailing-stop triggered:[-] price %.*f >= trail %.*f (trough %.*f, activation %.*f, trail %.2f%%)",
 							roundPrice, price, roundPrice, trailingStopPrice, roundPrice, lowestPrice, roundPrice, activationPrice, cfg.TrailingStop.TrailingPct))
-						buyBackQty := indicator.RoundFloat(sellProceeds/price, roundAmount)
+						// Apply configured buy-back buffer (default 0.2%) so the
+						// wallet's post-fee balance still covers the order. Without
+						// this the 0.1% commission already withheld by Binance can
+						// make the buy-back fail with insufficient balance.
+						buyBackFactor := 1 - cfg.BuyBackBuffer()/100
+						buyBackQty := indicator.RoundFloat((sellProceeds*buyBackFactor)/price, roundAmount)
 						buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
 						if err != nil {
 							dash.LogError(fmt.Sprintf("Trailing-Stop MARKET BUY failed: %v", err))
@@ -468,7 +474,8 @@ func bearTradeLoop(
 				pnlPct := (sellPrice - price) / sellPrice * 100
 				dash.LogInfo(fmt.Sprintf("[red]Stop-loss triggered:[-] price %.*f >= SL %.*f (sell %.*f, SL %.2f%%, P&L %+.2f%%)",
 					roundPrice, price, roundPrice, stopLossPrice, roundPrice, sellPrice, effectiveSL, pnlPct))
-				buyBackQty := indicator.RoundFloat(sellProceeds/price, roundAmount)
+				buyBackFactor := 1 - cfg.BuyBackBuffer()/100
+				buyBackQty := indicator.RoundFloat((sellProceeds*buyBackFactor)/price, roundAmount)
 				buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
 				if err != nil {
 					dash.LogError(fmt.Sprintf("Stop-Loss MARKET BUY failed: %v", err))
@@ -517,7 +524,11 @@ func bearTradeLoop(
 				if aiOrch != nil {
 					dash.LogInfo(fmt.Sprintf("  [green]✓[-] AI buy-back approved"))
 				}
-				buyBackQty := indicator.RoundFloat(sellProceeds/price, roundAmount)
+				// Account for buyFactor (limit price = price*buyFactor) and
+				// configured buy-back buffer (default 0.2%) to cover the
+				// 0.1% trading fee already deducted from sellProceeds.
+				buyBackFactor := 1 - cfg.BuyBackBuffer()/100
+				buyBackQty := indicator.RoundFloat((sellProceeds*buyBackFactor)/(price*buyFactor), roundAmount)
 				buy, err := TradeBuy(symbol, buyBackQty, price, buyFactor, roundPrice)
 				if err != nil {
 					dash.LogError(fmt.Sprintf("BUY order failed: %v", err))

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -42,6 +42,7 @@ func BullTrade(
 	if cfg.BaseURL != "" {
 		exchange.BaseURL = cfg.BaseURL
 	}
+	SetBuyBackBufferPct(cfg.BuyBackBuffer())
 	period := cfg.HistoricalPrices.Period     // length period for moving average
 	interval := cfg.HistoricalPrices.Interval // time intervals of historical prices for trading
 

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -45,6 +45,7 @@ func DynamicTrade(
 	if cfg.BaseURL != "" {
 		exchange.BaseURL = cfg.BaseURL
 	}
+	SetBuyBackBufferPct(cfg.BuyBackBuffer())
 	period := cfg.HistoricalPrices.Period
 	interval := cfg.HistoricalPrices.Interval
 
@@ -147,7 +148,7 @@ func dynamicEntryBalanceCheck(ticker string, isBull bool, qty, price, buyFactor,
 	return exchange.CheckOrderBalanceWithFilters(ticker, side, adjQty, entryPrice, filters)
 }
 
-func dynamicEntryBalanceAvailable(dash *tui.Dashboard, ticker string, isBull bool, qty, price, buyFactor, sellFactor float64, roundPrice, roundAmount uint) bool {
+func dynamicEntryBalanceAvailable(dash *tui.Dashboard, ticker string, isBull bool, qty, price, buyFactor, sellFactor float64, roundPrice, roundAmount uint, lastWaitState *string) bool {
 	check, err := dynamicEntryBalanceCheck(ticker, isBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount)
 	if err != nil {
 		dash.LogError(fmt.Sprintf("Entry balance check failed: %v", err))
@@ -160,8 +161,14 @@ func dynamicEntryBalanceAvailable(dash *tui.Dashboard, ticker string, isBull boo
 	if !isBull {
 		mode = "BEAR"
 	}
-	dash.LogInfo(fmt.Sprintf("[yellow]%s entry skipped[-] — %s %s needs %.8f %s, available %.8f; waiting for a compatible tendency",
-		mode, check.Symbol, check.Side, check.Required, check.Asset, check.Available))
+	state := fmt.Sprintf("balance-wait:%s:%.2f", mode, check.Required-check.Available)
+	if lastWaitState == nil || *lastWaitState != state {
+		dash.LogInfo(fmt.Sprintf("[yellow]%s entry skipped[-] — %s %s needs %.8f %s, available %.8f; waiting for a compatible tendency",
+			mode, check.Symbol, check.Side, check.Required, check.Asset, check.Available))
+		if lastWaitState != nil {
+			*lastWaitState = state
+		}
+	}
 	return false
 }
 
@@ -191,6 +198,9 @@ operationLoop:
 		dash.SetPhase("DETECTING TENDENCY")
 		var tendency string
 		var isBull bool
+		// Track the last waiting-state we logged so we only emit a message
+		// when the tendency (or wait-reason) changes, avoiding log spam.
+		var lastWaitState string
 
 		for {
 			var latestPrice float64
@@ -260,18 +270,26 @@ operationLoop:
 			// When a strategy is forced, wait for tendency to match
 			if strategy == "bull" && tendency != "up" {
 				dash.SetTradeMode("BULL (waiting)")
-				dash.LogInfo(fmt.Sprintf("[yellow]Tendency is %s[-] — waiting for [green]UP[-] tendency to match BULL strategy", tendency))
+				state := "bull-wait:" + tendency
+				if state != lastWaitState {
+					dash.LogInfo(fmt.Sprintf("[yellow]Tendency is %s[-] — waiting for [green]UP[-] tendency to match BULL strategy", tendency))
+					lastWaitState = state
+				}
 				time.Sleep(refreshInterval)
 				continue
 			}
 			if strategy == "bear" && tendency != "down" {
 				dash.SetTradeMode("BEAR (waiting)")
-				dash.LogInfo(fmt.Sprintf("[yellow]Tendency is %s[-] — waiting for [red]DOWN[-] tendency to match BEAR strategy", tendency))
+				state := "bear-wait:" + tendency
+				if state != lastWaitState {
+					dash.LogInfo(fmt.Sprintf("[yellow]Tendency is %s[-] — waiting for [red]DOWN[-] tendency to match BEAR strategy", tendency))
+					lastWaitState = state
+				}
 				time.Sleep(refreshInterval)
 				continue
 			}
 			candidateBull := tendency == "up"
-			if !dynamicEntryBalanceAvailable(dash, ticker, candidateBull, qty, latestPrice, buyFactor, sellFactor, roundPrice, roundAmount) {
+			if !dynamicEntryBalanceAvailable(dash, ticker, candidateBull, qty, latestPrice, buyFactor, sellFactor, roundPrice, roundAmount, &lastWaitState) {
 				if candidateBull {
 					dash.SetTradeMode("BULL (waiting balance)")
 				} else {
@@ -280,6 +298,7 @@ operationLoop:
 				time.Sleep(refreshInterval)
 				continue
 			}
+			lastWaitState = ""
 			break
 		}
 
@@ -327,7 +346,7 @@ operationLoop:
 					// auto mode: switch to the new tendency
 					dash.LogInfo(fmt.Sprintf("[yellow]Tendency flipped to %s during scanning — re-detecting[-]", tendency))
 					nextBull := tendency == "up"
-					if !dynamicEntryBalanceAvailable(dash, ticker, nextBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount) {
+					if !dynamicEntryBalanceAvailable(dash, ticker, nextBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount, nil) {
 						time.Sleep(refreshInterval)
 						continue operationLoop
 					}
@@ -618,7 +637,7 @@ operationLoop:
 			}
 
 			if shouldEnter {
-				if !dynamicEntryBalanceAvailable(dash, ticker, isBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount) {
+				if !dynamicEntryBalanceAvailable(dash, ticker, isBull, qty, price, buyFactor, sellFactor, roundPrice, roundAmount, nil) {
 					time.Sleep(refreshInterval)
 					continue operationLoop
 				}

--- a/strategy/helpers.go
+++ b/strategy/helpers.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wferreirauy/binance-bot/ai"
@@ -15,6 +16,92 @@ import (
 	"github.com/wferreirauy/binance-bot/storage"
 	"github.com/wferreirauy/binance-bot/tui"
 )
+
+// buyBackBuffer holds the configured safety buffer (in percent) used when
+// scaling a fresh order down to fit available wallet balance after fees.
+// It defaults to config.DefaultBuyBackBufferPct and is updated once per
+// strategy run via SetBuyBackBufferPct.
+var (
+	buyBackBufferMu  sync.RWMutex
+	buyBackBufferPct = config.DefaultBuyBackBufferPct
+)
+
+// SetBuyBackBufferPct overrides the package-level safety buffer percent.
+// A non-positive value resets it to the built-in default.
+func SetBuyBackBufferPct(pct float64) {
+	buyBackBufferMu.Lock()
+	defer buyBackBufferMu.Unlock()
+	if pct <= 0 {
+		buyBackBufferPct = config.DefaultBuyBackBufferPct
+		return
+	}
+	buyBackBufferPct = pct
+}
+
+// currentBuyBackBufferPct returns the active safety buffer percent.
+func currentBuyBackBufferPct() float64 {
+	buyBackBufferMu.RLock()
+	defer buyBackBufferMu.RUnlock()
+	return buyBackBufferPct
+}
+
+// reduceQtyForBalance returns the largest qty that respects the symbol's
+// exchange filters and the wallet's available balance, leaving the
+// configured safety buffer in place. It returns 0 when no valid order
+// can be placed with the available balance.
+func reduceQtyForBalance(side string, filters *exchange.SymbolFilters, available, price float64, round uint) float64 {
+	if filters == nil || price <= 0 || available <= 0 {
+		return 0
+	}
+	bufferFactor := 1 - currentBuyBackBufferPct()/100
+	if bufferFactor <= 0 || bufferFactor > 1 {
+		bufferFactor = 1
+	}
+	var raw float64
+	switch side {
+	case "BUY":
+		raw = (available * bufferFactor) / price
+	case "SELL":
+		raw = available * bufferFactor
+	default:
+		return 0
+	}
+	return exchange.AdjustQuantityDown(raw, price, filters, round)
+}
+
+// tryPlaceOrder runs the given placeFn; if it fails with insufficient
+// balance, it scales the qty down to fit the wallet's free balance
+// (minus the configured buffer) and retries once. On success it returns
+// the order, the effective qty, and any reduction message.
+func tryPlaceOrder(label, symbol, side string, qty, price float64, filters *exchange.SymbolFilters, round uint, placeFn func(qty float64) (any, error)) (any, float64, error) {
+	order, err := placeFn(qty)
+	if err == nil {
+		return order, qty, nil
+	}
+	if !exchange.IsInsufficientBalance(err) {
+		return nil, qty, err
+	}
+	// Re-fetch live balance and rescale.
+	asset := filters.QuoteAsset
+	if side == "SELL" {
+		asset = filters.BaseAsset
+	}
+	available, balErr := exchange.GetBalance(asset)
+	if balErr != nil {
+		return nil, qty, err
+	}
+	reducedQty := reduceQtyForBalance(side, filters, available, price, round)
+	if reducedQty <= 0 || reducedQty >= qty {
+		return nil, qty, err
+	}
+	fmt.Printf("%s qty reduced from %.8f to %.8f to fit %.8f %s available (buffer %.2f%%, %s)\n",
+		label, qty, reducedQty, available, asset, currentBuyBackBufferPct(), symbol)
+	order, err = placeFn(reducedQty)
+	if err != nil {
+		return nil, reducedQty, err
+	}
+	return order, reducedQty, nil
+}
 
 // TradeBuy places a LIMIT buy order
 func TradeBuy(ticker string, qty, basePrice, buyFactor float64, round uint) (any, error) {
@@ -30,7 +117,9 @@ func TradeBuy(ticker string, qty, basePrice, buyFactor float64, round uint) (any
 		fmt.Printf("BUY qty adjusted from %.8f to %.8f to meet exchange filters (minNotional=%.2f)\n", qty, adjQty, filters.MinNotional)
 	}
 
-	order, err := exchange.NewOrder(tick, "BUY", adjQty, buyPrice)
+	order, _, err := tryPlaceOrder("BUY", tick, "BUY", adjQty, buyPrice, filters, round, func(q float64) (any, error) {
+		return exchange.NewOrder(tick, "BUY", q, buyPrice)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +140,9 @@ func TradeSell(ticker string, qty, basePrice, sellFactor float64, round uint) (a
 		fmt.Printf("SELL qty adjusted from %.8f to %.8f to meet exchange filters (minNotional=%.2f)\n", qty, adjQty, filters.MinNotional)
 	}
 
-	order, err := exchange.NewOrder(tick, "SELL", adjQty, sellPrice)
+	order, _, err := tryPlaceOrder("SELL", tick, "SELL", adjQty, sellPrice, filters, round, func(q float64) (any, error) {
+		return exchange.NewOrder(tick, "SELL", q, sellPrice)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +162,9 @@ func TradeMarketBuy(ticker string, qty, estimatedPrice float64, round uint) (any
 		fmt.Printf("MARKET BUY qty adjusted from %.8f to %.8f to meet exchange filters (minNotional=%.2f)\n", qty, adjQty, filters.MinNotional)
 	}
 
-	order, err := exchange.NewMarketOrderWithPrice(tick, "BUY", adjQty, estimatedPrice)
+	order, _, err := tryPlaceOrder("MARKET BUY", tick, "BUY", adjQty, estimatedPrice, filters, round, func(q float64) (any, error) {
+		return exchange.NewMarketOrderWithPrice(tick, "BUY", q, estimatedPrice)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +184,9 @@ func TradeMarketSell(ticker string, qty, estimatedPrice float64, round uint) (an
 		fmt.Printf("MARKET SELL qty adjusted from %.8f to %.8f to meet exchange filters (minNotional=%.2f)\n", qty, adjQty, filters.MinNotional)
 	}
 
-	order, err := exchange.NewMarketOrderWithPrice(tick, "SELL", adjQty, estimatedPrice)
+	order, _, err := tryPlaceOrder("MARKET SELL", tick, "SELL", adjQty, estimatedPrice, filters, round, func(q float64) (any, error) {
+		return exchange.NewMarketOrderWithPrice(tick, "SELL", q, estimatedPrice)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -11,6 +11,10 @@ import (
 	"github.com/wferreirauy/binance-bot/config"
 )
 
+// Version is set by main at startup so the TUI can display the running
+// binary's semantic version. It defaults to "dev" for tests/local builds.
+var Version = "dev"
+
 // Dashboard manages the multi-panel terminal UI for the trading bot.
 type Dashboard struct {
 	app         *tview.Application
@@ -37,16 +41,26 @@ type Dashboard struct {
 
 	fileLogger *FileLogger
 	cfg        *config.Config
+
+	// logThrottle coalesces identical INFO log lines emitted within
+	// logThrottleWindow so the activity log and file logger don't fill
+	// with high-frequency status messages (e.g. "Tendency is ... —
+	// waiting"). Window <= 0 disables throttling.
+	logThrottleMu     sync.Mutex
+	logThrottleWindow time.Duration
+	logThrottleSeen   map[string]time.Time
 }
 
 // NewDashboard creates a new TUI dashboard with multi-panel layout.
 func NewDashboard(tradeMode, symbol string) *Dashboard {
 	d := &Dashboard{
-		app:       tview.NewApplication(),
-		tradeMode: tradeMode,
-		symbol:    symbol,
-		operation: 1,
-		phase:     "SCANNING",
+		app:               tview.NewApplication(),
+		tradeMode:         tradeMode,
+		symbol:            symbol,
+		operation:         1,
+		phase:             "SCANNING",
+		logThrottleWindow: 60 * time.Second,
+		logThrottleSeen:   make(map[string]time.Time),
 	}
 
 	// Header panel
@@ -172,8 +186,8 @@ func (d *Dashboard) headerText() string {
 	case "AUTO":
 		modeColor = "cyan"
 	}
-	return fmt.Sprintf("[%s::b]%s MODE[-] [white]|[-] [yellow::b]%s[-] [white]|[-] [cyan]Op #%d[-] [white]|[-] [aqua]%s[-] [white]| [red]q[-] quit [white]|[-] [blue]h[-] help [white]|[-] [green]c[-] config",
-		modeColor, d.tradeMode, d.symbol, d.operation, d.phase)
+	return fmt.Sprintf("[%s::b]%s MODE[-] [white]|[-] [yellow::b]%s[-] [white]|[-] [cyan]Op #%d[-] [white]|[-] [aqua]%s[-] [white]| [red]q[-] quit [white]|[-] [blue]h[-] help [white]|[-] [green]c[-] config [white]|[-] [dimgray]%s[-]",
+		modeColor, d.tradeMode, d.symbol, d.operation, d.phase, Version)
 }
 
 // SetTradeMode updates the trade mode displayed in the header (e.g. BULL, BEAR, AUTO).
@@ -692,6 +706,44 @@ func (d *Dashboard) SetFileLogger(fl *FileLogger) {
 	d.fileLogger = fl
 }
 
+// SetLogThrottleWindow configures how long identical INFO log lines are
+// coalesced. Pass 0 (or negative) to disable throttling. The default is
+// 60 seconds, applied at NewDashboard.
+func (d *Dashboard) SetLogThrottleWindow(window time.Duration) {
+	d.logThrottleMu.Lock()
+	defer d.logThrottleMu.Unlock()
+	d.logThrottleWindow = window
+	if d.logThrottleSeen == nil {
+		d.logThrottleSeen = make(map[string]time.Time)
+	}
+}
+
+// shouldEmitThrottled returns true when the given (stripped) message has
+// not been logged within the active throttle window. It records the
+// current timestamp for future calls when emission is allowed. A
+// non-positive window disables throttling entirely.
+func (d *Dashboard) shouldEmitThrottled(key string) bool {
+	d.logThrottleMu.Lock()
+	defer d.logThrottleMu.Unlock()
+	if d.logThrottleWindow <= 0 {
+		return true
+	}
+	now := time.Now()
+	if last, ok := d.logThrottleSeen[key]; ok && now.Sub(last) < d.logThrottleWindow {
+		return false
+	}
+	d.logThrottleSeen[key] = now
+	// Opportunistic cleanup: drop entries older than 5x the window so the
+	// map can't grow unbounded across long sessions.
+	cutoff := now.Add(-5 * d.logThrottleWindow)
+	for k, t := range d.logThrottleSeen {
+		if t.Before(cutoff) {
+			delete(d.logThrottleSeen, k)
+		}
+	}
+	return true
+}
+
 // LogOrder appends an order event to the activity log panel.
 func (d *Dashboard) LogOrder(text string) {
 	now := time.Now().Format("15:04:05")
@@ -707,6 +759,9 @@ func (d *Dashboard) LogOrder(text string) {
 
 // LogInfo appends an informational message to the activity log.
 func (d *Dashboard) LogInfo(msg string) {
+	if !d.shouldEmitThrottled("INFO|" + stripColorTags(msg)) {
+		return
+	}
 	now := time.Now().Format("15:04:05")
 	line := fmt.Sprintf("[gray]%s[-] [aqua]%s[-]\n", now, msg)
 	d.app.QueueUpdateDraw(func() {


### PR DESCRIPTION
## Summary

Four UX/robustness improvements driven by the prior session log review:

1. **Adaptive order retry on insufficient balance**
   When `NewOrder` / `NewMarketOrderWithPrice` returns `ErrInsufficientBalance`,
   the trade wrappers (`TradeBuy`, `TradeSell`, `TradeMarketBuy`,
   `TradeMarketSell`) now:
   - re-fetch the live wallet balance for the relevant asset,
   - scale the quantity *down* to the largest amount that still meets
     `LOT_SIZE` / `MIN_NOTIONAL` filters (using a new
     `exchange.AdjustQuantityDown`),
   - withhold the configured fee/safety buffer, and
   - retry the order once.
   If the truncated qty would violate exchange filters, the original
   error is surfaced unchanged. The reduction is logged via stdout
   (which the file logger also captures) so operators can see when a
   trade was downsized.

2. **Configurable fee / safety buffer**
   New config field `fees.buy-back-buffer-pct` (default **0.2%**, exposed via
   `config.DefaultBuyBackBufferPct` and `cfg.BuyBackBuffer()`).
   Replaces the hard-coded `0.998` multiplier used by the BEAR
   take-profit / trailing-stop / stop-loss buy-back paths and drives the
   new retry-with-reduced-qty logic. Users running with BNB-discounted
   fees can lower this; the legacy 0.2% remains the safe default.
   Validation rejects negative values.

3. **Throttled INFO log lines**
   `Dashboard.LogInfo` now coalesces identical messages within a
   configurable window (default 60 s). The previous run produced
   thousands of `Tendency is up — waiting for DOWN ...` lines on every
   refresh; only the first within the window is emitted to the TUI
   activity log and the file logger. The map is bounded by opportunistic
   cleanup at 5× the window. `SetLogThrottleWindow(0)` disables it for
   tests or verbose debugging.

4. **Version visible in the TUI**
   The dashboard header now ends with the running binary's semantic
   version (`tui.Version`, set once in `main.go` from `app.Version`).
   No extra layout changes; the version appears in the existing top bar
   alongside mode/symbol/op/phase and the keyboard hints.

## Changes

- `config/file.go` — add `Fees.BuyBackBufferPct` YAML field.
- `config/fees.go` *(new)* — `DefaultBuyBackBufferPct = 0.2` and
  `Config.BuyBackBuffer()` helper.
- `config/validation.go` — validate `fees.buy-back-buffer-pct >= 0`.
- `exchange/order.go` — add `AdjustQuantityDown` (floor-to-step variant
  used when fitting available balance).
- `strategy/helpers.go` — package-level `buyBackBufferPct` + setter,
  `tryPlaceOrder` retry helper; `TradeBuy`/`TradeSell`/`TradeMarketBuy`/
  `TradeMarketSell` rewritten to use it.
- `strategy/bear.go` — replace hard-coded `0.998` buy-back multiplier
  with `cfg.BuyBackBuffer()` in all three exit paths (TP, trailing-stop,
  stop-loss); call `SetBuyBackBufferPct(cfg.BuyBackBuffer())` at startup.
- `strategy/bull.go`, `strategy/dynamic.go` — set the buffer at startup.
  (Their existing `qty * 0.998` sell-back multipliers were left intact
  because they operate on the base asset after-fee balance and are
  conceptually independent.)
- `tui/dashboard.go` — add `Version` package var; show it in the header;
  add log-throttle state, `SetLogThrottleWindow`, and `shouldEmitThrottled`;
  `LogInfo` consults the throttle.
- `main.go` — import `tui`; set `tui.Version = app.Version` before `Run`.
- `README.md`, `sample-binance-config.yml`, `sample-scalp-config.yml` —
  document `fees.buy-back-buffer-pct`, retry-on-insufficient-balance
  behavior, and bump the help-block version to `v0.13.0`.
- `main.go` — bump `Version` to `v0.13.0`.

## Validation

- `go build ./...` — clean.
- `go test ./...` — all packages pass (`config`, `ai`, `exchange`,
  `indicator`).

## Notes

- Log throttle window is currently 60 s and is set in `NewDashboard`.
  If users ask for it, exposing a `log.throttle-secs` config field is a
  one-line follow-up (just call `dash.SetLogThrottleWindow(...)` after
  `NewDashboard`).
- The retry only runs once per call to keep behavior predictable; a
  second `ErrInsufficientBalance` (e.g. concurrent withdrawal) still
  bubbles up.