### PR TITLE
fix(strategy): correct RSI entry thresholds - bull uses lower-limit, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ The `bull-trade` command is designed to operate during **bull market trends**, l
 
 In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` out of 6 are bullish (see [Scalp Mode Configuration](#scalp-mode-configuration)).
 
-1. **RSI**: Value is below the configured `upper-limit` (default 70), indicating the market is not overbought.
+1. **RSI**: Value is below the configured `lower-limit` (default 30), indicating the market is oversold and ripe for a reversal upward.
 2. **MACD Crossover**: The MACD line crosses above the Signal line (classic) or is above the Signal line (scalp), suggesting upward momentum.
 3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
@@ -639,7 +639,7 @@ In **classic mode**, all conditions must be met simultaneously. In **scalp mode*
 
 The bot will open a short position (sell) when:
 
-1. **RSI**: Value is above the configured `lower-limit` (default 30), indicating the market is not oversold.
+1. **RSI**: Value is above the configured `upper-limit` (default 70), indicating the market is overbought and ripe for a reversal downward.
 2. **MACD Crossover**: The MACD line crosses below the Signal line, suggesting downward momentum.
 3. **Tendency**: The trend direction is "down" (DEMA below EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Upper Band than the Lower Band, suggesting a potential reversal from overbought conditions.

--- a/config/README.md
+++ b/config/README.md
@@ -137,9 +137,9 @@ Relative Strength Index — measures momentum to detect overbought/oversold cond
 |-----------|------|---------|-------------|
 | `interval` | string | - | Candlestick interval for RSI price data (can differ from the main trading interval). |
 | `length` | int | - | Number of periods for RSI calculation. Standard is 14; lower values are more reactive. |
-| `upper-limit` | int | - | RSI above this value is considered overbought. In bull mode, entry is blocked above this. |
+| `upper-limit` | int | - | RSI above this value is considered overbought. In bear mode, entry requires RSI above this threshold. |
 | `middle-limit` | int | - | Neutral RSI level (informational). |
-| `lower-limit` | int | - | RSI below this value is considered oversold. In bear mode, entry is blocked below this. |
+| `lower-limit` | int | - | RSI below this value is considered oversold. In bull mode, entry requires RSI below this threshold. |
 
 ```yaml
 indicators:

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.13.0",
+		Version:  "v0.13.1",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -255,12 +255,12 @@ func bearTradeLoop(
 				score := 0
 				var conditions []entryCondition
 
-				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.LowerLimit)
+				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
 				if rsiOk {
 					score++
 				}
 				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("RSI %.1f > %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
+					Name: fmt.Sprintf("RSI %.1f > %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
 					Met:  rsiOk,
 				})
 
@@ -319,7 +319,7 @@ func bearTradeLoop(
 					}
 				}
 			} else {
-				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.LowerLimit)
+				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
 				macdCrossOk := macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] &&
 					macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
 				tendOk := tendency == "down"
@@ -330,7 +330,7 @@ func bearTradeLoop(
 
 				if shouldSell {
 					conditions := []entryCondition{
-						{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
+						{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
 						{Name: fmt.Sprintf("MACD bearish crossover (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
 						{Name: fmt.Sprintf("Tendency %s = down", tendency), Met: tendOk},
 						{Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower), Met: bbOk},

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -254,12 +254,12 @@ func bullTradeLoop(
 				score := 0
 				var conditions []entryCondition
 
-				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit)
+				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
 				if rsiOk {
 					score++
 				}
 				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("RSI %.1f < %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
+					Name: fmt.Sprintf("RSI %.1f < %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
 					Met:  rsiOk,
 				})
 
@@ -318,7 +318,7 @@ func bullTradeLoop(
 					}
 				}
 			} else {
-				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit)
+				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
 				macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
 					macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
 				tendOk := tendency == "up"
@@ -329,7 +329,7 @@ func bullTradeLoop(
 
 				if shouldBuy {
 					conditions := []entryCondition{
-						{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
+						{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
 						{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
 						{Name: fmt.Sprintf("Tendency %s = up", tendency), Met: tendOk},
 						{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -486,12 +486,12 @@ operationLoop:
 				var conditions []entryCondition
 
 				if isBull {
-					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit)
+					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
 					if rsiOk {
 						score++
 					}
 					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("RSI %.1f < %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
+						Name: fmt.Sprintf("RSI %.1f < %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
 						Met:  rsiOk,
 					})
 
@@ -522,12 +522,12 @@ operationLoop:
 						Met:  bbOk,
 					})
 				} else {
-					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.LowerLimit)
+					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
 					if rsiOk {
 						score++
 					}
 					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("RSI %.1f > %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
+						Name: fmt.Sprintf("RSI %.1f > %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
 						Met:  rsiOk,
 					})
 
@@ -592,7 +592,7 @@ operationLoop:
 				}
 			} else {
 				if isBull {
-					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit)
+					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
 					macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
 						macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
 					tendOk := tendency == "up"
@@ -603,7 +603,7 @@ operationLoop:
 
 					if shouldEnter {
 						conditions := []entryCondition{
-							{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
+							{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
 							{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
 							{Name: fmt.Sprintf("Tendency %s = up", tendency), Met: tendOk},
 							{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},
@@ -613,7 +613,7 @@ operationLoop:
 						logEntryConditions(dash, "BULL", conditions, 6, 6, 6, false)
 					}
 				} else {
-					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.LowerLimit)
+					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
 					macdCrossOk := macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] &&
 						macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
 					tendOk := tendency == "down"
@@ -624,7 +624,7 @@ operationLoop:
 
 					if shouldEnter {
 						conditions := []entryCondition{
-							{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
+							{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
 							{Name: fmt.Sprintf("MACD bearish crossover (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
 							{Name: fmt.Sprintf("Tendency %s = down", tendency), Met: tendOk},
 							{Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower), Met: bbOk},

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -89,7 +89,7 @@ func (classicBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	distanceToLower := math.Abs(currentDema - lowerBand)
 	macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
 		macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
-	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) &&
+	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit) &&
 		macdCrossOk &&
 		snapshot.Tendency == "up" &&
 		distanceToLower < distanceToUpper {
@@ -128,7 +128,7 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	currentDema := dema[len(dema)-1]
 	lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
 	upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.UpperLimit) {
+	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit) {
 		score++
 	}
 	if macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] {


### PR DESCRIPTION
# fix: correct RSI threshold logic for entries (v0.13.1)

## Summary

Fixes inverted RSI threshold checks in the entry conditions for both bull
and bear strategies. The RSI gate was comparing against the wrong limit,
which made it almost always pass in normal market conditions instead of
filtering for true oversold (bull) or overbought (bear) setups.

## Problem

Standard RSI semantics:
- RSI **below** the lower limit (e.g. `< 30`) = **oversold** → buying opportunity
- RSI **above** the upper limit (e.g. `> 70`) = **overbought** → shorting opportunity

The codebase previously did the opposite of what an entry filter should do:
- Bull entries (buy): `rsi < UpperLimit` (e.g. `< 70`) — only excluded extreme
  overbought, allowing entries even when RSI was at 65, 50, 40, etc.
- Bear entries (sell short): `rsi > LowerLimit` (e.g. `> 30`) — only excluded
  extreme oversold, allowing entries even when RSI was at 35, 50, 65, etc.

In practice this meant the RSI condition was almost always "met", contributing
no real filtering and producing trades far from genuine reversal zones.

## Fix

- Bull entry: now requires `rsi < LowerLimit` (true oversold).
- Bear entry: now requires `rsi > UpperLimit` (true overbought).

Applied consistently across:
- `strategy/registry.go` (classic-bull, scalp-bull registered strategies used by backtest)
- `strategy/bull.go` (live bull-trade entries, classic + scalp)
- `strategy/bear.go` (live bear-trade entries, classic + scalp)
- `strategy/dynamic.go` (auto-trade live entries, classic + scalp, both bull and bear branches)

Dashboard/log condition labels updated to reflect the corrected comparison
(e.g. `RSI 28.4 < 30 (lower limit)` for bull, `RSI 73.1 > 70 (upper limit)`
for bear).

## Docs

- `README.md` — Trading Strategy Logic: bull buy condition now describes
  oversold RSI (`< lower-limit`); bear sell condition describes overbought
  RSI (`> upper-limit`).
- `config/README.md` — RSI section updated to reflect that `lower-limit`
  gates bull entries and `upper-limit` gates bear entries.

## Version

`v0.13.0` → `v0.13.1` (patch — bug fix, no config/CLI changes).

## Tests

- `go build ./...` — OK
- `go test ./...` — all packages pass