### PR TITLE
fix: MACD scalp momentum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,23 @@
 # Project Guidelines
 
+Before applying any change, make sure to update the local files with the remote git repo, `git pull`.
+Amd for every new task, follow the git workflow indicated bellow, ensuring to create a new branch of updated main.
+
+## Git Workflow
+
+For every change set, follow this workflow:
+
+1. **Create a new branch** off `main` with a descriptive name reflecting the change
+   (e.g. `feat/<short-desc>`, `fix/<short-desc>`, `docs/<short-desc>`,
+   `chore/<short-desc>`).
+2. **Stage** the relevant files (`git add <files>`).
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/)
+   and include the bumped semantic version in the message
+   (e.g. `feat(strategy): add RSI divergence detector (v0.13.0)`,
+   `fix(tui): prevent panel race on shutdown (v0.12.2)`,
+   `docs: add CONTRIBUTING.md (v0.12.1)`).
+4. **Push** the branch to the remote (`git push -u origin <branch>`).
+
 ## Versioning
 
 The application version is defined in `main.go` on the `Version` field of the `cli.App` struct.
@@ -36,18 +54,3 @@ This includes:
 
 ## Release
 On every new changes on new branch, rewrite completely the file PR-description-draft.md, that will be used to create the PR with the new changes created. Create the file if does not exist.
-
-## Git Workflow
-
-For every change set, follow this workflow:
-
-1. **Create a new branch** off `main` with a descriptive name reflecting the change
-   (e.g. `feat/<short-desc>`, `fix/<short-desc>`, `docs/<short-desc>`,
-   `chore/<short-desc>`).
-2. **Stage** the relevant files (`git add <files>`).
-3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/)
-   and include the bumped semantic version in the message
-   (e.g. `feat(strategy): add RSI divergence detector (v0.13.0)`,
-   `fix(tui): prevent panel race on shutdown (v0.12.2)`,
-   `docs: add CONTRIBUTING.md (v0.12.1)`).
-4. **Push** the branch to the remote (`git push -u origin <branch>`).

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ All log levels (orders, info, errors) are automatically written to `binance-bot.
 ```
 2026-04-07 12:30:00 [INFO]  Scalp entry: score 5/6 (min 5)
 2026-04-07 12:30:00 [INFO]    ✓ RSI 28.4 < 30 (upper limit)
-2026-04-07 12:30:00 [INFO]    ✓ MACD above signal (0.000012 > 0.000008)
+2026-04-07 12:30:00 [INFO]    ✓ MACD histogram rising (0.000012 > 0.000008)
 2026-04-07 12:30:00 [INFO]    ✓ Tendency up = up
 2026-04-07 12:30:00 [INFO]    ✓ Closer to lower BB (lower=0.0023, upper=0.0089)
 2026-04-07 12:30:00 [INFO]    ✓ ADX strong (32.1 > 20)
@@ -609,7 +609,7 @@ The `bull-trade` command is designed to operate during **bull market trends**, l
 In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` out of 6 are bullish (see [Scalp Mode Configuration](#scalp-mode-configuration)).
 
 1. **RSI**: Value is below the configured `lower-limit` (default 30), indicating the market is oversold and ripe for a reversal upward.
-2. **MACD Crossover**: The MACD line crosses above the Signal line (classic) or is above the Signal line (scalp), suggesting upward momentum.
+2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is positive **and** rising bar-over-bar (scalp), confirming building upward momentum rather than a stale above-signal state.
 3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
@@ -640,7 +640,7 @@ In **classic mode**, all conditions must be met simultaneously. In **scalp mode*
 The bot will open a short position (sell) when:
 
 1. **RSI**: Value is above the configured `upper-limit` (default 70), indicating the market is overbought and ripe for a reversal downward.
-2. **MACD Crossover**: The MACD line crosses below the Signal line, suggesting downward momentum.
+2. **MACD Momentum**: The MACD line crosses below the Signal line (classic) or the MACD histogram (`macd − signal`) is negative **and** falling bar-over-bar (scalp), confirming building downward momentum.
 3. **Tendency**: The trend direction is "down" (DEMA below EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Upper Band than the Lower Band, suggesting a potential reversal from overbought conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX confirms the trend has strength.

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.13.1",
+		Version:  "v0.13.2",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -264,12 +264,14 @@ func bearTradeLoop(
 					Met:  rsiOk,
 				})
 
-				macdOk := macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
+				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
+				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
+				macdOk := hist < 0 && hist < prevHist
 				if macdOk {
 					score++
 				}
 				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("MACD below signal (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]),
+					Name: fmt.Sprintf("MACD histogram falling (%.6f < %.6f)", hist, prevHist),
 					Met:  macdOk,
 				})
 

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -263,12 +263,14 @@ func bullTradeLoop(
 					Met:  rsiOk,
 				})
 
-				macdOk := macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
+				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
+				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
+				macdOk := hist > 0 && hist > prevHist
 				if macdOk {
 					score++
 				}
 				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("MACD above signal (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]),
+					Name: fmt.Sprintf("MACD histogram rising (%.6f > %.6f)", hist, prevHist),
 					Met:  macdOk,
 				})
 

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -495,12 +495,14 @@ operationLoop:
 						Met:  rsiOk,
 					})
 
-					macdOk := macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
+					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
+					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
+					macdOk := hist > 0 && hist > prevHist
 					if macdOk {
 						score++
 					}
 					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("MACD above signal (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]),
+						Name: fmt.Sprintf("MACD histogram rising (%.6f > %.6f)", hist, prevHist),
 						Met:  macdOk,
 					})
 
@@ -531,12 +533,14 @@ operationLoop:
 						Met:  rsiOk,
 					})
 
-					macdOk := macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
+					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
+					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
+					macdOk := hist < 0 && hist < prevHist
 					if macdOk {
 						score++
 					}
 					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("MACD below signal (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]),
+						Name: fmt.Sprintf("MACD histogram falling (%.6f < %.6f)", hist, prevHist),
 						Met:  macdOk,
 					})
 

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -121,7 +121,7 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	rsi := indicator.CalculateRSI(closes, cfg.Indicators.Rsi.Length)
 	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
-	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) == 0 || len(signalLine) == 0 || len(bb.LowerBand) == 0 {
+	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
 		return SignalHold
 	}
 	score := 0
@@ -131,7 +131,9 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit) {
 		score++
 	}
-	if macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] {
+	hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
+	prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
+	if hist > 0 && hist > prevHist {
 		score++
 	}
 	if snapshot.Tendency == "up" {


### PR DESCRIPTION
# fix: require MACD histogram momentum for scalp entries (v0.13.2)

## Summary

Strengthens the MACD condition used by **scalp mode** entries so that scoring
requires *building* momentum in the trade direction, not just a stale
above/below-signal state. Classic mode (fresh crossover) is unchanged.

## Problem

In scalp mode the MACD score counted only the static relationship on the
latest bar:
- Bull scalp: `macd > signal`
- Bear scalp: `macd < signal`

That latest bar can occur many candles after the actual crossover, when the
histogram `(macd − signal)` is already contracting and price has rolled
over. On a 1m scalp timeframe this admits late entries right when momentum
is fading — the worst time to enter for a quick profit.

Classic mode already required a *fresh* crossover (previous bar on the
wrong side, current bar on the right side), so it does not have this issue.

## Fix

Scalp mode now requires the MACD **histogram** to be in the trade direction
**and** expanding bar-over-bar:

- Bull scalp: `hist > 0` **and** `hist > prevHist` (positive and rising)
- Bear scalp: `hist < 0` **and** `hist < prevHist` (negative and falling)

where `hist = macd − signal`, `prevHist` is the same quantity one bar back.

This keeps scalp more permissive than classic (no strict crossover
required) while ensuring momentum is accelerating in the trade direction at
entry — improving trade quality and reducing late-entry losses.

## Files touched

- `strategy/registry.go` — `scalp-bull` registered strategy (used by backtest); also tightens the data-length guard to `len(macd) >= 2`.
- `strategy/bull.go` — live `bull-trade` scalp entries.
- `strategy/bear.go` — live `bear-trade` scalp entries.
- `strategy/dynamic.go` — `auto-trade` scalp entries (both bull and bear branches).
- Dashboard/log condition labels updated to reflect the new check:
  `MACD histogram rising (hist > prevHist)` / `MACD histogram falling (hist < prevHist)`.

## Docs

- `README.md` — Trading Strategy Logic: MACD bullet for both bull and bear
  now describes the scalp momentum variant; example log line updated.

## Version

`v0.13.1` → `v0.13.2` (patch — scalp entry behavior tightened; no config
or CLI changes).

## Tests

- `go build ./...` — OK
- `go test ./...` — all packages pass