### PR TITLE
feat(tui): show live ATR in indicators panel (v0.13.3)

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.13.2",
+		Version:  "v0.13.3",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -206,12 +206,20 @@ func bearTradeLoop(
 			}
 
 			// Update indicators panel
+			var atrVal float64
+			if cfg.Indicators.Atr.Period > 0 {
+				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+				if len(atrSeries) > 0 {
+					atrVal = atrSeries[len(atrSeries)-1]
+				}
+			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
 				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
 				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
 				Volume: currentVolume, AvgVolume: avgVolume,
+				ATR: atrVal, Price: price,
 			})
 
 			// AI analysis
@@ -406,9 +414,17 @@ func bearTradeLoop(
 
 			// update indicators with P&L
 			pnl := (sellPrice - price) / sellPrice * 100
+			var atrVal float64
+			if cfg.Indicators.Atr.Period > 0 {
+				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+				if len(atrSeries) > 0 {
+					atrVal = atrSeries[len(atrSeries)-1]
+				}
+			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 				Tendency: fmt.Sprintf("P&L: %+.2f%%", pnl),
+				ATR:      atrVal, Price: price,
 			})
 
 			if price < lowestPrice {

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -205,12 +205,20 @@ func bullTradeLoop(
 			}
 
 			// Update indicators panel
+			var atrVal float64
+			if cfg.Indicators.Atr.Period > 0 {
+				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+				if len(atrSeries) > 0 {
+					atrVal = atrSeries[len(atrSeries)-1]
+				}
+			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
 				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
 				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
 				Volume: currentVolume, AvgVolume: avgVolume,
+				ATR: atrVal, Price: price,
 			})
 
 			// AI analysis
@@ -404,9 +412,17 @@ func bullTradeLoop(
 
 			// update indicators panel with sell-phase data
 			pnl := (price - buyPrice) / buyPrice * 100
+			var atrVal float64
+			if cfg.Indicators.Atr.Period > 0 {
+				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+				if len(atrSeries) > 0 {
+					atrVal = atrSeries[len(atrSeries)-1]
+				}
+			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 				Tendency: fmt.Sprintf("P&L: %+.2f%%", pnl),
+				ATR:      atrVal, Price: price,
 			})
 
 			if price > highestPrice {

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -239,12 +239,20 @@ operationLoop:
 							avgVolume = volumeMA[len(volumeMA)-1]
 						}
 					}
+					var atrVal float64
+					if cfg.Indicators.Atr.Period > 0 {
+						atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+						if len(atrSeries) > 0 {
+							atrVal = atrSeries[len(atrSeries)-1]
+						}
+					}
 					dash.UpdateIndicators(&tui.IndicatorData{
 						RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 						MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
 						DEMA: dema[len(dema)-1], UpperBand: bb.UpperBand[len(bb.UpperBand)-1], LowerBand: bb.LowerBand[len(bb.LowerBand)-1],
 						Tendency: "(detecting)", ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
 						Volume: currentVolume, AvgVolume: avgVolume,
+						ATR: atrVal, Price: price,
 					})
 
 				}
@@ -422,12 +430,20 @@ operationLoop:
 			}
 
 			// Update indicators panel
+			var atrVal float64
+			if cfg.Indicators.Atr.Period > 0 {
+				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+				if len(atrSeries) > 0 {
+					atrVal = atrSeries[len(atrSeries)-1]
+				}
+			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
 				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
 				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
 				Volume: currentVolume, AvgVolume: avgVolume,
+				ATR: atrVal, Price: price,
 			})
 
 			// AI analysis
@@ -741,9 +757,17 @@ operationLoop:
 				dash.UpdatePrice(price, prevPrice, roundPrice)
 
 				pnl := (price - entryPrice) / entryPrice * 100
+				var atrVal float64
+				if cfg.Indicators.Atr.Period > 0 {
+					atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+					if len(atrSeries) > 0 {
+						atrVal = atrSeries[len(atrSeries)-1]
+					}
+				}
 				dash.UpdateIndicators(&tui.IndicatorData{
 					RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 					Tendency: fmt.Sprintf("P&L: %+.2f%%", pnl),
+					ATR:      atrVal, Price: price,
 				})
 
 				if price > highestPrice {
@@ -900,9 +924,17 @@ operationLoop:
 				dash.UpdatePrice(price, prevPrice, roundPrice)
 
 				pnl := (entryPrice - price) / entryPrice * 100
+				var atrVal float64
+				if cfg.Indicators.Atr.Period > 0 {
+					atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
+					if len(atrSeries) > 0 {
+						atrVal = atrSeries[len(atrSeries)-1]
+					}
+				}
 				dash.UpdateIndicators(&tui.IndicatorData{
 					RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
 					Tendency: fmt.Sprintf("P&L: %+.2f%%", pnl),
+					ATR:      atrVal, Price: price,
 				})
 
 				if price < lowestPrice {

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -433,6 +433,8 @@ type IndicatorData struct {
 	ADXThreshold  int
 	Volume        float64
 	AvgVolume     float64
+	ATR           float64 // latest ATR in price units
+	Price         float64 // latest close, used to render ATR%
 }
 
 // SetRefreshInterval stores the polling interval and starts a 1-second
@@ -562,6 +564,15 @@ func (d *Dashboard) UpdateIndicators(ind *IndicatorData) {
 		b.WriteString(fmt.Sprintf(" [white::b]ADX:[:-]         [%s]%.1f[-]", adxColor, ind.ADX))
 		if ind.ADXThreshold > 0 {
 			b.WriteString(fmt.Sprintf(" [gray](threshold: %d)[-]", ind.ADXThreshold))
+		}
+		b.WriteString("\n")
+	}
+
+	// ATR (volatility)
+	if ind.ATR > 0 {
+		b.WriteString(fmt.Sprintf(" [white::b]ATR:[:-]         [aqua]%.6f[-]", ind.ATR))
+		if ind.Price > 0 {
+			b.WriteString(fmt.Sprintf(" [gray](%.3f%%)[-]", ind.ATR/ind.Price*100))
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
# feat(tui): show live ATR in indicators panel (v0.13.3)

## Summary

ATR (Average True Range) was computed by the bot for trailing-stop logic
but never surfaced in the TUI. This PR adds ATR to the live Indicators
panel so the user can see current volatility while waiting for entries and
during open positions — useful for tuning stop-loss / take-profit relative
to current market conditions.

## What changed

- `tui/dashboard.go`
  - `IndicatorData` gains two fields: `ATR float64` (price units) and
    `Price float64` (latest close, used to render ATR as a percentage).
  - Render adds an `ATR:` row between `ADX:` and `Volume:` showing the raw
    value and `(X.XXX%)` of price, only when ATR > 0.
- `strategy/dynamic.go`, `strategy/bull.go`, `strategy/bear.go`
  - At every `UpdateIndicators(...)` call site (pre-entry scanning and
    in-position monitoring, 8 sites total), compute the latest ATR when
    `cfg.Indicators.Atr.Period > 0` and pass it together with the latest
    close price.

No config or CLI changes. ATR row is hidden when `atr.period` is unset or
when not enough data is available yet.

## Why

The previous PR draft mentioned using ATR as a basis for sizing scalp
TP/SL but there was no way to read it from the running bot — only the
configured *period* was visible in the static Config panel. Surfacing the
live value lets users size:

- Stop-loss ≈ `1× ATR%`
- Take-profit ≈ `1.2–1.5× ATR%`

without resorting to external charts.

## Version

`v0.13.2` → `v0.13.3` (patch — new TUI display only, no behavior change to
trading logic).

## Tests

- `go build ./...` — OK
- `go test ./...` — all packages pass