### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build and test


### PR DESCRIPTION
Potential fix for [https://github.com/wferreirauy/binance-bot/security/code-scanning/1](https://github.com/wferreirauy/binance-bot/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
For this workflow, the best minimal fix is at the workflow root (applies to all jobs), setting:

- `contents: read`

This preserves existing behavior (checkout/build/test) while preventing unintended write scopes from inherited defaults.  
Edit `.github/workflows/test.yml` by inserting the `permissions` block after the `on` triggers and before `jobs`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
