### PR TITLE
Feat/macd anticipatory scalp

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.14.0
+     v0.14.1
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 - **Auto Trade** — Automatically detects market tendency and switches between bull/bear strategies per operation; supports forced strategy mode and waits when the account cannot fund the detected side
 - **Bull Trade** — Buy-low-sell-high strategy for uptrending markets
 - **Bear Trade** — Sell-high-buy-low strategy for downtrending markets
-- **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system; no longer requires all signals simultaneously
+- **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system. v0.14.0 adds pullback-in-trend RSI, anticipatory MACD with optional consecutive-bar confirmation, Bollinger price-touch + squeeze, RSI-divergence bonus, ATR regime filter, recent-extreme guard, ATR-based TP/SL, time-stop, break-even pin, and MACD-peak exit
+- **Advanced Indicators** — RSI (+ optional SMA smoothing), MACD, DEMA, Bollinger Bands (+ width-ratio for squeeze), ADX, ATR, Stochastic RSI, swing-extrema divergence, and volume confirmation
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
 - **Rotation Scout Mode** — Scans a configured asset basket and rotates through a bridge asset when relative ratios become fee-adjusted opportunities
 - **Backtesting** — Runs registered strategy simulations over recent Binance candles before live trading
@@ -18,7 +19,6 @@
 - **AI Multi-Agent System** — Concurrent analysis from OpenAI, DeepSeek, and Claude with weighted consensus; when enabled, entries require explicit AI approval at the configured confidence threshold
 - **Sentiment Analysis** — Real-time news headlines and Fear & Greed Index integrated into AI decisions
 - **Trailing Stop-Loss** — Dynamically locks in profits as price moves favorably
-- **Advanced Indicators** — RSI, MACD, DEMA, Bollinger Bands, ADX, ATR, and volume confirmation
 - **Full OHLCV Analysis** — Uses complete candlestick data instead of close-only prices
 - **Auto-Notional Adjustment** — Automatically raises order quantity to meet Binance's minimum notional filter
 - **Config Validation** — Checks the YAML config file before starting a trading session
@@ -234,7 +234,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.13.0
+     v0.14.0
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -375,12 +375,14 @@ indicators:
     upper-limit: 70
     middle-limit: 50
     lower-limit: 30
+    smooth-length: 0      # >1 applies an SMA smoothing to RSI (e.g. 3)
   dema:
     length: 9
   macd:
     fast-length: 12
     slow-length: 26
     signal-length: 9
+    consecutive-bars: 0   # require N consecutive bars of histogram direction (0=no requirement)
   bollinger-bands:
     length: 20
     multiplier: 2.0
@@ -411,10 +413,12 @@ indicators:
 | `indicators.rsi.upper-limit` | int | `70` | Overbought threshold; must be above `middle-limit`. |
 | `indicators.rsi.middle-limit` | int | `50` | Neutral RSI threshold. |
 | `indicators.rsi.lower-limit` | int | `30` | Oversold threshold; must be below `middle-limit`. |
+| `indicators.rsi.smooth-length` | int | `0` | Applies an SMA smoothing of N to the RSI series (0/1 disables, behaves identically to v0.13.x). |
 | `indicators.dema.length` | int | `9` | DEMA lookback length for trend/proximity checks. |
 | `indicators.macd.fast-length` | int | `12` | Fast MACD EMA length; must be less than `slow-length`. |
 | `indicators.macd.slow-length` | int | `26` | Slow MACD EMA length. |
 | `indicators.macd.signal-length` | int | `9` | MACD signal EMA length. |
+| `indicators.macd.consecutive-bars` | int | `0` | Require histogram direction to hold for N consecutive bars to award the MACD scalp signal (0=last-bar only). |
 | `indicators.bollinger-bands.length` | int | `20` | Bollinger moving average length. |
 | `indicators.bollinger-bands.multiplier` | float | `2.0` | Standard deviation multiplier for band width. |
 | `indicators.atr.period` | int | `14` | ATR volatility lookback used by dynamic stop-loss logic. |
@@ -441,7 +445,7 @@ For bull trades, the stop tracks from the highest price after activation. For be
 
 ### Scalp Mode
 
-Scalp mode uses a score instead of requiring all six entry conditions at once. The six signals are RSI, MACD, tendency, Bollinger position, ADX strength, and volume confirmation.
+Scalp mode uses a score instead of requiring all entry conditions at once. The default signals are RSI pullback-in-trend, anticipatory MACD histogram, tendency / MACD zero-line gate, Bollinger price-touch, ADX strength and volume confirmation. Optional weighted scoring boosts MACD/RSI/BB (×2) and divergence (×3) so quality signals dominate quantity.
 
 ```yaml
 scalp-mode:
@@ -455,12 +459,30 @@ scalp-mode:
   cooldown-base-secs: 60
   atr-stop-loss: false
   atr-multiplier: 1.5
+  # --- v0.14.0 indicator overhaul (all opt-in) ---
+  weighted-scoring: false
+  bb-squeeze-enabled: false
+  bb-squeeze-ratio: 0.85
+  bb-squeeze-window: 20
+  volume-strong-multiplier: 0.0      # e.g. 1.5 → bonus if vol > 1.5×avg
+  divergence-enabled: false
+  divergence-lookback: 14
+  divergence-swing-pad: 2
+  fast-trend-gate: false             # accept tendency OR MACD zero-line
+  tp-atr-multiplier: 0.0             # 0=use takeProfit %; >0 → max(takeProfit%, mult × ATR%)
+  sl-atr-multiplier: 0.0             # 0=use atr-multiplier; >0 → max(stopLoss%, mult × ATR%)
+  time-stop-bars: 0                  # exit flat positions after N bars (0=off)
+  breakeven-atr-mult: 0.0            # pin SL to entry once peak P&L ≥ mult × ATR%
+  min-atr-pct: 0.0                   # regime filter — skip entries when ATR% below this
+  max-atr-pct: 0.0                   # regime filter — skip entries when ATR% above this
+  macd-peak-exit: false              # exit in profit when MACD histogram rolls over
+  recent-extreme-bars: 0             # skip BULL near recent high / BEAR near recent low
 ```
 
 | Field | Type | Sample | Description |
 |-------|------|--------|-------------|
 | `scalp-mode.enabled` | bool | `false` | Enables score-based scalp entries. |
-| `scalp-mode.min-score` | int | `3` | Required matching signals out of 6; valid range is 1-6 when enabled. |
+| `scalp-mode.min-score` | int | `3` | Required score threshold (unweighted: out of 6; weighted: out of higher max with bonuses). |
 | `scalp-mode.post-buy-delay` | int | `30` | Seconds to wait after fill before exit monitoring. |
 | `scalp-mode.inter-op-delay` | int | `60` | Seconds to wait between completed operations. |
 | `scalp-mode.require-rsi-exit` | bool | `true` | Requires RSI momentum confirmation for take-profit exits when true. |
@@ -469,6 +491,23 @@ scalp-mode:
 | `scalp-mode.cooldown-base-secs` | int | `60` | Base cooldown seconds; doubles after additional consecutive stop-losses. |
 | `scalp-mode.atr-stop-loss` | bool | `false` | Uses ATR as a dynamic stop-loss floor. |
 | `scalp-mode.atr-multiplier` | float | `1.5` | Dynamic floor multiplier: `max(configured SL, atr-multiplier * ATR%)`. |
+| `scalp-mode.weighted-scoring` | bool | `false` | Doubles MACD/RSI/BB weight (×2) and divergence (×3). |
+| `scalp-mode.bb-squeeze-enabled` | bool | `false` | Adds a bonus signal when Bollinger band width is compressed (energy build-up). |
+| `scalp-mode.bb-squeeze-ratio` | float | `0.85` | BB width must be ≤ this × average width to qualify as a squeeze. |
+| `scalp-mode.bb-squeeze-window` | int | `20` | Lookback window for the BB-width average. |
+| `scalp-mode.volume-strong-multiplier` | float | `0.0` | If >0, awards a bonus signal when current volume > mult × avg-volume. |
+| `scalp-mode.divergence-enabled` | bool | `false` | Adds a (weighted) bonus signal on bullish/bearish RSI divergence. |
+| `scalp-mode.divergence-lookback` | int | `14` | Bars to scan for swing extrema in divergence detection. |
+| `scalp-mode.divergence-swing-pad` | int | `2` | Padding around extrema for swing detection. |
+| `scalp-mode.fast-trend-gate` | bool | `false` | Accepts trend signal if either tendency aligns OR MACD line is on the bullish/bearish side of zero. |
+| `scalp-mode.tp-atr-multiplier` | float | `0.0` | If >0, take-profit becomes `max(takeProfit%, mult × ATR%)`. |
+| `scalp-mode.sl-atr-multiplier` | float | `0.0` | If >0, stop-loss becomes `max(stopLoss%, mult × ATR%)`. Overrides `atr-multiplier` when set. |
+| `scalp-mode.time-stop-bars` | int | `0` | Exits flat (P&L≥0 but TP not reached) positions after N bars. |
+| `scalp-mode.breakeven-atr-mult` | float | `0.0` | Once peak P&L ≥ mult × ATR%, pins the stop-loss to the entry price. |
+| `scalp-mode.min-atr-pct` | float | `0.0` | Regime filter — refuse entries when ATR% is below this threshold (dead market). |
+| `scalp-mode.max-atr-pct` | float | `0.0` | Regime filter — refuse entries when ATR% is above this threshold (chaotic market). |
+| `scalp-mode.macd-peak-exit` | bool | `false` | Exits in profit when MACD histogram rolls over for 3 consecutive bars. |
+| `scalp-mode.recent-extreme-bars` | int | `0` | Blocks BULL entries near a recent high (BEAR near recent low) over the given lookback. |
 
 ### AI
 
@@ -606,24 +645,32 @@ The `bull-trade` command is designed to operate during **bull market trends**, l
 
 #### **Buy Conditions**
 
-In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` out of 6 are bullish (see [Scalp Mode Configuration](#scalp-mode-configuration)).
+In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` is reached (see [Scalp Mode Configuration](#scalp-mode-configuration)). Scalp mode uses *pullback-in-trend RSI* (RSI rising from below mid-line) and *Bollinger price-touch* (close at/below lower band) — both designed to catch turning points earlier than the classic extreme thresholds.
 
-1. **RSI**: Value is below the configured `lower-limit` (default 30), indicating the market is oversold and ripe for a reversal upward.
-2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is rising bar-over-bar (scalp). The scalp variant fires anticipatorily: it does not require MACD to already be above signal, only that the gap is closing (or already-positive gap widening) — getting the entry *before* the crossover when momentum begins shifting up.
-3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA).
-4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
+1. **RSI**: Classic: value below `lower-limit` (default 30). Scalp: pullback-in-trend (RSI below mid-line and rising for 2 bars), plus optional SMA smoothing via `indicators.rsi.smooth-length`.
+2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is rising bar-over-bar (scalp). The scalp variant fires anticipatorily and can require N consecutive bars of confirmation via `indicators.macd.consecutive-bars`.
+3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA). With `scalp-mode.fast-trend-gate`, MACD line above zero alternatively satisfies the trend.
+4. **Bollinger Position**: Classic: DEMA closer to Lower than Upper Band. Scalp: close at/below the lower band (price touch).
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
-6. **Volume Confirmation** *(if configured)*: Current volume exceeds its moving average, avoiding false breakouts.
-7. **AI Consensus** *(if enabled)*: The multi-agent system must explicitly approve the entry at or above `ai.min-confidence`.
+6. **Volume Confirmation** *(if configured)*: Current volume exceeds its MA. `scalp-mode.volume-strong-multiplier` awards a bonus when volume exceeds mult × MA.
+7. **Bollinger Squeeze** *(scalp, opt-in)*: Bonus signal when BB width compresses below its rolling average (energy build-up).
+8. **Divergence** *(scalp, opt-in)*: Bullish RSI divergence vs. price awards a weighted-×3 bonus.
+9. **AI Consensus** *(if enabled)*: The multi-agent system must explicitly approve the entry at or above `ai.min-confidence`.
+
+Scalp mode also applies two **gates** that can veto an entry outright before scoring:
+- **Regime filter** (`min-atr-pct` / `max-atr-pct`): refuses trades when ATR% indicates a dead or chaotic market.
+- **Recent-extreme block** (`recent-extreme-bars`): blocks BULL entries within 0.1×ATR of a recent high (BEAR mirror).
 
 Before submitting the buy order, the bot verifies that the account has enough free quote-asset balance, such as USDT for `XRP/USDT`.
 
 #### **Sell Conditions**
-The bot will exit a position through one of three mechanisms:
+The bot will exit a position through one of five mechanisms:
 
 1. **Trailing Stop-Loss** *(if enabled)*: After the price rises by `activation-pct` above buy price, the stop trails from the highest price. Triggers when price drops by `trailing-pct` from the peak.
-2. **Fixed Stop-Loss**: The price drops to the stop-loss percentage below buy price. Executes immediately (no AI delay on protective exits).
-3. **Take Profit**: The price reaches the take-profit percentage AND RSI is declining (skipped in scalp mode when `require-rsi-exit: false`) AND the AI supports the exit (if enabled).
+2. **Fixed Stop-Loss**: The price drops to the stop-loss percentage below buy price (widened by `atr-stop-loss`/`sl-atr-multiplier` if configured; pinned to entry by `breakeven-atr-mult` once peak P&L is reached). Executes immediately.
+3. **Time-Stop** *(scalp, opt-in)*: Exits flat positions (P&L ≥ 0, TP not reached) after `time-stop-bars` bars.
+4. **MACD-Peak Exit** *(scalp, opt-in)*: Exits in profit when the MACD histogram rolls over (3-bar peak), locking gains before reversal.
+5. **Take Profit**: The price reaches `effectiveTP = max(takeProfit%, tp-atr-multiplier × ATR%)` AND RSI is declining (skipped in scalp mode when `require-rsi-exit: false`) AND the AI supports the exit (if enabled).
 
 Before submitting an exit sell order, the bot verifies that the account has enough free base-asset balance for the quantity being sold.
 
@@ -650,11 +697,13 @@ The bot will open a short position (sell) when:
 Before submitting the sell entry, the bot verifies that the account has enough free base-asset balance, such as BTC for `BTC/USDT`.
 
 #### **Buy-Back Exit Conditions**
-The bot will exit the bear position (buy back) through one of three mechanisms:
+The bot will exit the bear position (buy back) through one of five mechanisms (same set as bull, mirrored):
 
 1. **Trailing Stop** *(if enabled)*: After the price drops by `activation-pct` below sell price, the stop trails from the lowest price. Triggers when price rises by `trailing-pct` from the trough.
-2. **Fixed Stop-Loss**: The price rises to the stop-loss percentage above sell price. Executes immediately.
-3. **Take Profit**: The price drops to the take-profit percentage AND RSI is rising (skipped in scalp mode when `require-rsi-exit: false`) AND the AI supports the exit (if enabled).
+2. **Fixed Stop-Loss**: The price rises to the stop-loss percentage above sell price (widened or break-even-pinned as in bull). Executes immediately.
+3. **Time-Stop** *(scalp, opt-in)*: Exits flat positions after `time-stop-bars` bars.
+4. **MACD-Peak Exit** *(scalp, opt-in)*: Exits in profit when the bearish MACD histogram rolls over.
+5. **Take Profit**: The price drops to `effectiveTP = max(takeProfit%, tp-atr-multiplier × ATR%)` AND RSI is rising (skipped in scalp mode when `require-rsi-exit: false`) AND the AI supports the exit (if enabled).
 
 Before submitting a buy-back order, the bot verifies that the account has enough free quote-asset balance for the estimated cost.
 

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ The `bull-trade` command is designed to operate during **bull market trends**, l
 In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` out of 6 are bullish (see [Scalp Mode Configuration](#scalp-mode-configuration)).
 
 1. **RSI**: Value is below the configured `lower-limit` (default 30), indicating the market is oversold and ripe for a reversal upward.
-2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is positive **and** rising bar-over-bar (scalp), confirming building upward momentum rather than a stale above-signal state.
+2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is rising bar-over-bar (scalp). The scalp variant fires anticipatorily: it does not require MACD to already be above signal, only that the gap is closing (or already-positive gap widening) — getting the entry *before* the crossover when momentum begins shifting up.
 3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Lower Band than the Upper Band, suggesting a potential reversal from oversold conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
@@ -640,7 +640,7 @@ In **classic mode**, all conditions must be met simultaneously. In **scalp mode*
 The bot will open a short position (sell) when:
 
 1. **RSI**: Value is above the configured `upper-limit` (default 70), indicating the market is overbought and ripe for a reversal downward.
-2. **MACD Momentum**: The MACD line crosses below the Signal line (classic) or the MACD histogram (`macd − signal`) is negative **and** falling bar-over-bar (scalp), confirming building downward momentum.
+2. **MACD Momentum**: The MACD line crosses below the Signal line (classic) or the MACD histogram (`macd − signal`) is falling bar-over-bar (scalp). The scalp variant fires anticipatorily: it does not require MACD to already be below signal, only that the gap is closing (or already-negative gap widening) — entering *before* the bearish crossover when momentum begins shifting down.
 3. **Tendency**: The trend direction is "down" (DEMA below EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Upper Band than the Lower Band, suggesting a potential reversal from overbought conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX confirms the trend has strength.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Auto Trade** — Automatically detects market tendency and switches between bull/bear strategies per operation; supports forced strategy mode and waits when the account cannot fund the detected side
 - **Bull Trade** — Buy-low-sell-high strategy for uptrending markets
 - **Bear Trade** — Sell-high-buy-low strategy for downtrending markets
-- **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system. v0.14.0 adds pullback-in-trend RSI, anticipatory MACD with optional consecutive-bar confirmation, Bollinger price-touch + squeeze, RSI-divergence bonus, ATR regime filter, recent-extreme guard, ATR-based TP/SL, time-stop, break-even pin, and MACD-peak exit
+- **Scalp Mode** — High-frequency micro-trading using a scoring-based entry system. v0.14.0 adds pullback-in-trend RSI, anticipatory MACD with optional consecutive-bar confirmation, Bollinger price-touch + squeeze, RSI-divergence bonus, ATR regime filter, recent-extreme guard, ATR-based TP/SL, time-stop, break-even pin, and MACD-peak exit. v0.14.2 adds the MACD `min-separation` gate so entries only fire after a meaningful prior MACD/signal gap is now closing in
 - **Advanced Indicators** — RSI (+ optional SMA smoothing), MACD, DEMA, Bollinger Bands (+ width-ratio for squeeze), ADX, ATR, Stochastic RSI, swing-extrema divergence, and volume confirmation
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
 - **Rotation Scout Mode** — Scans a configured asset basket and rotates through a bridge asset when relative ratios become fee-adjusted opportunities
@@ -234,7 +234,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.14.1
+     v0.14.2
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>
@@ -383,6 +383,8 @@ indicators:
     slow-length: 26
     signal-length: 9
     consecutive-bars: 0   # require N consecutive bars of histogram direction (0=no requirement)
+    min-separation: 0.0   # require |max hist| within lookback to reach this threshold before MACD signal fires (0=disabled)
+    min-separation-lookback: 20  # bars to scan for prior peak histogram separation when min-separation > 0
   bollinger-bands:
     length: 20
     multiplier: 2.0
@@ -419,6 +421,8 @@ indicators:
 | `indicators.macd.slow-length` | int | `26` | Slow MACD EMA length. |
 | `indicators.macd.signal-length` | int | `9` | MACD signal EMA length. |
 | `indicators.macd.consecutive-bars` | int | `0` | Require histogram direction to hold for N consecutive bars to award the MACD scalp signal (0=last-bar only). |
+| `indicators.macd.min-separation` | float | `0` | When > 0, the MACD scalp signal additionally requires the histogram to have reached ≥ this threshold in the prior direction within the lookback (bull: hist ≤ −min-separation, bear: hist ≥ +min-separation). Filters out flat-MACD noise so entries only fire when a meaningful prior MACD/signal gap is now closing in. Typical value: `0.002`. |
+| `indicators.macd.min-separation-lookback` | int | `20` | How many bars to scan for the prior peak histogram separation when `min-separation > 0`. |
 | `indicators.bollinger-bands.length` | int | `20` | Bollinger moving average length. |
 | `indicators.bollinger-bands.multiplier` | float | `2.0` | Standard deviation multiplier for band width. |
 | `indicators.atr.period` | int | `14` | ATR volatility lookback used by dynamic stop-loss logic. |
@@ -648,7 +652,7 @@ The `bull-trade` command is designed to operate during **bull market trends**, l
 In **classic mode**, the bot places a buy order when **all** of the following conditions are true simultaneously. In **scalp mode**, the conditions are scored and entry triggers when `min-score` is reached (see [Scalp Mode Configuration](#scalp-mode-configuration)). Scalp mode uses *pullback-in-trend RSI* (RSI rising from below mid-line) and *Bollinger price-touch* (close at/below lower band) — both designed to catch turning points earlier than the classic extreme thresholds.
 
 1. **RSI**: Classic: value below `lower-limit` (default 30). Scalp: pullback-in-trend (RSI below mid-line and rising for 2 bars), plus optional SMA smoothing via `indicators.rsi.smooth-length`.
-2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is rising bar-over-bar (scalp). The scalp variant fires anticipatorily and can require N consecutive bars of confirmation via `indicators.macd.consecutive-bars`.
+2. **MACD Momentum**: The MACD line crosses above the Signal line (classic) or the MACD histogram (`macd − signal`) is rising bar-over-bar (scalp). The scalp variant fires anticipatorily and can require N consecutive bars of confirmation via `indicators.macd.consecutive-bars`. When `indicators.macd.min-separation` is set, the signal additionally requires the histogram to have been at least that far below zero within the lookback window — i.e. MACD must have meaningfully diverged below signal before now closing the gap, filtering out flat-MACD noise.
 3. **Tendency Confirmation**: The trend direction is "up" (DEMA above EMA). With `scalp-mode.fast-trend-gate`, MACD line above zero alternatively satisfies the trend.
 4. **Bollinger Position**: Classic: DEMA closer to Lower than Upper Band. Scalp: close at/below the lower band (price touch).
 5. **ADX Trend Strength** *(if configured)*: ADX is above the threshold (default 25), confirming a strong trend.
@@ -687,7 +691,7 @@ In **classic mode**, all conditions must be met simultaneously. In **scalp mode*
 The bot will open a short position (sell) when:
 
 1. **RSI**: Value is above the configured `upper-limit` (default 70), indicating the market is overbought and ripe for a reversal downward.
-2. **MACD Momentum**: The MACD line crosses below the Signal line (classic) or the MACD histogram (`macd − signal`) is falling bar-over-bar (scalp). The scalp variant fires anticipatorily: it does not require MACD to already be below signal, only that the gap is closing (or already-negative gap widening) — entering *before* the bearish crossover when momentum begins shifting down.
+2. **MACD Momentum**: The MACD line crosses below the Signal line (classic) or the MACD histogram (`macd − signal`) is falling bar-over-bar (scalp). The scalp variant fires anticipatorily: it does not require MACD to already be below signal, only that the gap is closing (or already-negative gap widening) — entering *before* the bearish crossover when momentum begins shifting down. When `indicators.macd.min-separation` is set, the signal additionally requires the histogram to have been at least that far above zero within the lookback (mirror of the bull rule).
 3. **Tendency**: The trend direction is "down" (DEMA below EMA).
 4. **DEMA Proximity to Bollinger Bands**: The current DEMA is closer to the Upper Band than the Lower Band, suggesting a potential reversal from overbought conditions.
 5. **ADX Trend Strength** *(if configured)*: ADX confirms the trend has strength.

--- a/config/file.go
+++ b/config/file.go
@@ -41,19 +41,21 @@ type Config struct {
 	} `yaml:"tendency"`
 	Indicators struct {
 		Rsi struct {
-			Interval    string `yaml:"interval"`
-			Length      int    `yaml:"length"`
-			UpperLimit  int    `yaml:"upper-limit"`
-			MiddleLimit int    `yaml:"middle-limit"`
-			LowerLimit  int    `yaml:"lower-limit"`
+			Interval     string `yaml:"interval"`
+			Length       int    `yaml:"length"`
+			UpperLimit   int    `yaml:"upper-limit"`
+			MiddleLimit  int    `yaml:"middle-limit"`
+			LowerLimit   int    `yaml:"lower-limit"`
+			SmoothLength int    `yaml:"smooth-length"` // optional EMA pre-smoothing of price before RSI (0/1 = off)
 		} `yaml:"rsi"`
 		Dema struct {
 			Length int `yaml:"length"`
 		} `yaml:"dema"`
 		Macd struct {
-			FastLength   int `yaml:"fast-length"`
-			SlowLength   int `yaml:"slow-length"`
-			SignalLength int `yaml:"signal-length"`
+			FastLength      int `yaml:"fast-length"`
+			SlowLength      int `yaml:"slow-length"`
+			SignalLength    int `yaml:"signal-length"`
+			ConsecutiveBars int `yaml:"consecutive-bars"` // require N consecutive bars of histogram in direction for scalp (default 1)
 		} `yaml:"macd"`
 		BollingerBands struct {
 			Length     int     `yaml:"length"`
@@ -93,7 +95,7 @@ type Config struct {
 	RefreshInterval int `yaml:"refresh-interval"`
 	ScalpMode       struct {
 		Enabled          bool    `yaml:"enabled"`
-		MinScore         int     `yaml:"min-score"`          // min bullish signals out of 6 to trigger entry
+		MinScore         int     `yaml:"min-score"`          // min bullish signals to trigger entry (compared against weighted or unweighted total)
 		PostBuyDelay     int     `yaml:"post-buy-delay"`     // seconds to wait after buy fill before sell monitoring
 		InterOpDelay     int     `yaml:"inter-op-delay"`     // seconds to wait between operations
 		RequireRSIExit   bool    `yaml:"require-rsi-exit"`   // require RSI declining for take-profit
@@ -102,6 +104,25 @@ type Config struct {
 		CooldownBaseSecs int     `yaml:"cooldown-base-secs"` // base cooldown seconds, doubles each time (default: 60)
 		ATRStopLoss      bool    `yaml:"atr-stop-loss"`      // use ATR-based dynamic stop-loss floor
 		ATRMultiplier    float64 `yaml:"atr-multiplier"`     // SL = max(configured, atrMultiplier × ATR%) (default: 1.5)
+
+		// --- v0.14 scalp improvements (all opt-in unless noted) ---
+		WeightedScoring        bool    `yaml:"weighted-scoring"`         // use weighted signals (MACD=2, RSI=2, BB=2, Divergence=3, others=1)
+		BBSqueezeEnabled       bool    `yaml:"bb-squeeze-enabled"`       // add a score point when bands are squeezed (width/avg < bb-squeeze-ratio)
+		BBSqueezeRatio         float64 `yaml:"bb-squeeze-ratio"`         // squeeze threshold (default 0.6)
+		BBSqueezeWindow        int     `yaml:"bb-squeeze-window"`        // avg-width lookback bars (default 20)
+		VolumeStrongMultiplier float64 `yaml:"volume-strong-multiplier"` // required ratio of current/avg volume for vol signal (default 1.5)
+		DivergenceEnabled      bool    `yaml:"divergence-enabled"`       // detect RSI bullish/bearish divergence and add high-weight score
+		DivergenceLookback     int     `yaml:"divergence-lookback"`      // bars to search for swings (default 30)
+		DivergenceSwingPad     int     `yaml:"divergence-swing-pad"`     // bars of confirmation on each side of swing (default 2)
+		FastTrendGate          bool    `yaml:"fast-trend-gate"`          // require MACD line above zero for bull / below for bear (faster than DEMA tendency)
+		TPATRMultiplier        float64 `yaml:"tp-atr-multiplier"`        // when > 0, take-profit % = (ATR/price * 100) × this (overrides --tp)
+		SLATRMultiplier        float64 `yaml:"sl-atr-multiplier"`        // when > 0, stop-loss % = (ATR/price * 100) × this (overrides --sl; orthogonal to ATRStopLoss floor)
+		TimeStopBars           int     `yaml:"time-stop-bars"`           // when > 0, exit at-or-above breakeven after N bars without TP
+		BreakevenATRMult       float64 `yaml:"breakeven-atr-mult"`       // when > 0, raise SL to entry once price moves this many ATRs in profit
+		MinATRPct              float64 `yaml:"min-atr-pct"`              // when > 0, skip entries while ATR% < this (avoid dead-flat regime)
+		MaxATRPct              float64 `yaml:"max-atr-pct"`              // when > 0, skip entries while ATR% > this (avoid news-driven chaos)
+		MACDPeakExit           bool    `yaml:"macd-peak-exit"`           // exit when MACD histogram peaks in profit, before TP/SL hit
+		RecentExtremeBars      int     `yaml:"recent-extreme-bars"`      // when > 0, block entries against a fresh N-bar extreme
 	} `yaml:"scalp-mode"`
 	TopGainers struct {
 		QuoteAsset     string   `yaml:"quote-asset"`

--- a/config/file.go
+++ b/config/file.go
@@ -52,10 +52,12 @@ type Config struct {
 			Length int `yaml:"length"`
 		} `yaml:"dema"`
 		Macd struct {
-			FastLength      int `yaml:"fast-length"`
-			SlowLength      int `yaml:"slow-length"`
-			SignalLength    int `yaml:"signal-length"`
-			ConsecutiveBars int `yaml:"consecutive-bars"` // require N consecutive bars of histogram in direction for scalp (default 1)
+			FastLength      int     `yaml:"fast-length"`
+			SlowLength      int     `yaml:"slow-length"`
+			SignalLength    int     `yaml:"signal-length"`
+			ConsecutiveBars int     `yaml:"consecutive-bars"`        // require N consecutive bars of histogram in direction for scalp (default 1)
+			MinSeparation   float64 `yaml:"min-separation"`          // when > 0, require histogram had |hist| >= this within the lookback (meaningful prior MACD/signal divergence) before now closing in
+			MinSepLookback  int     `yaml:"min-separation-lookback"` // bars to scan for the prior peak separation (default 20 when min-separation > 0)
 		} `yaml:"macd"`
 		BollingerBands struct {
 			Length     int     `yaml:"length"`

--- a/indicator/extras.go
+++ b/indicator/extras.go
@@ -1,0 +1,175 @@
+package indicator
+
+import "math"
+
+// CalculateSmoothedRSI applies an EMA(smoothLength) to prices before computing
+// the standard RSI. When smoothLength <= 1 it is equivalent to CalculateRSI.
+// Smoothing reduces noise on fast (1m) candles without significantly delaying
+// turning points.
+func CalculateSmoothedRSI(prices []float64, period, smoothLength int) []float64 {
+	if smoothLength <= 1 {
+		return CalculateRSI(prices, period)
+	}
+	smoothed, err := CalculateEMA(prices, smoothLength)
+	if err != nil || len(smoothed) == 0 {
+		return CalculateRSI(prices, period)
+	}
+	return CalculateRSI(smoothed, period)
+}
+
+// CalculateStochRSI computes Stochastic-RSI: %K of RSI over a lookback window.
+// Returns values in [0,1]. Useful on 1m for catching turns 1-2 bars earlier
+// than raw RSI, at the cost of more noise.
+func CalculateStochRSI(prices []float64, rsiPeriod, stochPeriod int) []float64 {
+	rsi := CalculateRSI(prices, rsiPeriod)
+	if len(rsi) < stochPeriod {
+		return []float64{}
+	}
+	out := make([]float64, 0, len(rsi)-stochPeriod+1)
+	for i := stochPeriod - 1; i < len(rsi); i++ {
+		minV := rsi[i-stochPeriod+1]
+		maxV := minV
+		for j := i - stochPeriod + 2; j <= i; j++ {
+			if rsi[j] < minV {
+				minV = rsi[j]
+			}
+			if rsi[j] > maxV {
+				maxV = rsi[j]
+			}
+		}
+		if maxV == minV {
+			out = append(out, 0.5)
+			continue
+		}
+		out = append(out, (rsi[i]-minV)/(maxV-minV))
+	}
+	return out
+}
+
+// BollingerWidthRatio returns the latest band width (upper-lower) divided by
+// the average band width over the last `avgWindow` bars. A return value below
+// ~0.6 typically indicates a squeeze (low volatility coiling).
+func BollingerWidthRatio(bb BollingerBands, avgWindow int) float64 {
+	n := len(bb.UpperBand)
+	if n == 0 || avgWindow <= 0 || n < avgWindow {
+		return 0
+	}
+	current := bb.UpperBand[n-1] - bb.LowerBand[n-1]
+	if current <= 0 {
+		return 0
+	}
+	var sum float64
+	for i := n - avgWindow; i < n; i++ {
+		sum += bb.UpperBand[i] - bb.LowerBand[i]
+	}
+	avg := sum / float64(avgWindow)
+	if avg <= 0 {
+		return 0
+	}
+	return current / avg
+}
+
+// findSwingExtrema locates indices of local minima (lows=true) or maxima
+// (lows=false) where the bar is strictly more extreme than `lookback`
+// neighbors on each side. Returns indices in ascending order.
+func findSwingExtrema(prices []float64, lookback int, lows bool) []int {
+	if lookback < 1 || len(prices) < 2*lookback+1 {
+		return nil
+	}
+	var out []int
+	for i := lookback; i < len(prices)-lookback; i++ {
+		extreme := true
+		for j := 1; j <= lookback; j++ {
+			if lows {
+				if prices[i-j] <= prices[i] || prices[i+j] <= prices[i] {
+					extreme = false
+					break
+				}
+			} else {
+				if prices[i-j] >= prices[i] || prices[i+j] >= prices[i] {
+					extreme = false
+					break
+				}
+			}
+		}
+		if extreme {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// BullishDivergence reports true when, within the last `lookback` bars of
+// `closes`/`oscillator` (same length), price made a lower low but the
+// oscillator made a higher low at the two most recent swings.
+func BullishDivergence(closes, oscillator []float64, lookback, swingPad int) bool {
+	if len(closes) != len(oscillator) || len(closes) < lookback {
+		return false
+	}
+	start := len(closes) - lookback
+	priceSlice := closes[start:]
+	oscSlice := oscillator[start:]
+	priceLows := findSwingExtrema(priceSlice, swingPad, true)
+	if len(priceLows) < 2 {
+		return false
+	}
+	oscLows := findSwingExtrema(oscSlice, swingPad, true)
+	if len(oscLows) < 2 {
+		return false
+	}
+	pA, pB := priceLows[len(priceLows)-2], priceLows[len(priceLows)-1]
+	oA, oB := oscLows[len(oscLows)-2], oscLows[len(oscLows)-1]
+	// require swings to be roughly aligned (within swingPad bars)
+	if math.Abs(float64(pA-oA)) > float64(swingPad) || math.Abs(float64(pB-oB)) > float64(swingPad) {
+		return false
+	}
+	return priceSlice[pB] < priceSlice[pA] && oscSlice[oB] > oscSlice[oA]
+}
+
+// BearishDivergence reports true when, within the last `lookback` bars, price
+// made a higher high but the oscillator made a lower high at the two most
+// recent swings.
+func BearishDivergence(closes, oscillator []float64, lookback, swingPad int) bool {
+	if len(closes) != len(oscillator) || len(closes) < lookback {
+		return false
+	}
+	start := len(closes) - lookback
+	priceSlice := closes[start:]
+	oscSlice := oscillator[start:]
+	priceHighs := findSwingExtrema(priceSlice, swingPad, false)
+	if len(priceHighs) < 2 {
+		return false
+	}
+	oscHighs := findSwingExtrema(oscSlice, swingPad, false)
+	if len(oscHighs) < 2 {
+		return false
+	}
+	pA, pB := priceHighs[len(priceHighs)-2], priceHighs[len(priceHighs)-1]
+	oA, oB := oscHighs[len(oscHighs)-2], oscHighs[len(oscHighs)-1]
+	if math.Abs(float64(pA-oA)) > float64(swingPad) || math.Abs(float64(pB-oB)) > float64(swingPad) {
+		return false
+	}
+	return priceSlice[pB] > priceSlice[pA] && oscSlice[oB] < oscSlice[oA]
+}
+
+// RecentExtremeLookback returns the highest and lowest closes within the last
+// `lookback` bars (excluding the most recent bar). Useful for deciding whether
+// the latest bar prints a fresh extreme that should block counter-trend
+// entries.
+func RecentExtremeLookback(closes []float64, lookback int) (high, low float64) {
+	n := len(closes)
+	if lookback <= 0 || n < lookback+1 {
+		return 0, 0
+	}
+	high = closes[n-lookback-1]
+	low = high
+	for i := n - lookback - 1; i < n-1; i++ {
+		if closes[i] > high {
+			high = closes[i]
+		}
+		if closes[i] < low {
+			low = closes[i]
+		}
+	}
+	return high, low
+}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.14.1",
+		Version:  "v0.14.2",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.14.0",
+		Version:  "v0.14.1",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.13.3",
+		Version:  "v0.13.4",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.13.4",
+		Version:  "v0.14.0",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -41,12 +41,14 @@ indicators:
     upper-limit: 70
     middle-limit: 50
     lower-limit: 30
+    # smooth-length: 0   # SMA smoothing applied to RSI (0/1 disables; e.g. 3 reduces flicker)
   dema:
     length: 9
   macd:
     fast-length: 12
     slow-length: 26
     signal-length: 9
+    # consecutive-bars: 0  # require N consecutive bars of histogram direction (0=last-bar only)
   bollinger-bands:
     length: 20
     multiplier: 2.0
@@ -62,12 +64,14 @@ trailing-stop:
   activation-pct: 1.5  # activate after 1.5% profit
   trailing-pct: 1.0    # trail by 1.0% from peak
 
-# Scalp mode: relaxed entry conditions for high-frequency micro-trading
-# When enabled, uses a scoring system (min-score out of 6 signals) instead of
-# requiring ALL entry conditions to be true simultaneously.
+# Scalp mode: relaxed entry conditions for high-frequency micro-trading.
+# When enabled, uses a scoring system (min-score) instead of requiring ALL
+# entry conditions to be true simultaneously. All v0.14.0 fields are opt-in:
+# defaults of 0/false preserve v0.13.x behavior (with two intentional scalp
+# default changes: pullback-in-trend RSI and Bollinger price-touch).
 scalp-mode:
   enabled: false
-  min-score: 3           # minimum bullish signals out of 6 to trigger entry
+  min-score: 3           # required score (unweighted out of 6; weighted higher when bonuses active)
   post-buy-delay: 30     # seconds to wait after fill before exit monitoring
   inter-op-delay: 60     # seconds to wait between completed operations
   require-rsi-exit: true # require RSI declining/rising for take-profit
@@ -76,6 +80,24 @@ scalp-mode:
   cooldown-base-secs: 60 # base cooldown seconds (doubles each consecutive SL)
   atr-stop-loss: false   # ATR-based dynamic stop-loss floor
   atr-multiplier: 1.5    # SL = max(configured, atrMultiplier × ATR%)
+  # --- v0.14.0 indicator overhaul (all opt-in; 0 / false = unchanged) ---
+  # weighted-scoring: false        # MACD/RSI/BB count ×2, divergence ×3
+  # bb-squeeze-enabled: false      # bonus when BB width compressed (energy build-up)
+  # bb-squeeze-ratio: 0.85         # current width ≤ ratio × avg width qualifies as squeeze
+  # bb-squeeze-window: 20          # lookback for BB-width average
+  # volume-strong-multiplier: 0.0  # >0 → bonus when current volume > mult × avg
+  # divergence-enabled: false      # bonus on bullish/bearish RSI divergence
+  # divergence-lookback: 14        # bars to scan for swing extrema
+  # divergence-swing-pad: 2        # padding around extrema
+  # fast-trend-gate: false         # trend signal: tendency aligns OR MACD on correct side of zero
+  # tp-atr-multiplier: 0.0         # >0 → TP = max(takeProfit%, mult × ATR%)
+  # sl-atr-multiplier: 0.0         # >0 → SL = max(stopLoss%, mult × ATR%) (overrides atr-multiplier when set)
+  # time-stop-bars: 0              # exit flat positions (P&L≥0, TP not reached) after N bars
+  # breakeven-atr-mult: 0.0        # pin SL to entry once peak P&L ≥ mult × ATR%
+  # min-atr-pct: 0.0               # regime filter: refuse entries below this ATR%
+  # max-atr-pct: 0.0               # regime filter: refuse entries above this ATR%
+  # macd-peak-exit: false          # exit in profit when MACD histogram rolls over (3-bar peak)
+  # recent-extreme-bars: 0         # block BULL near recent high / BEAR near recent low
 
 # AI multi-agent configuration
 # API keys are read from environment variables:

--- a/sample-binance-config.yml
+++ b/sample-binance-config.yml
@@ -49,6 +49,8 @@ indicators:
     slow-length: 26
     signal-length: 9
     # consecutive-bars: 0  # require N consecutive bars of histogram direction (0=last-bar only)
+    # min-separation: 0.0  # require |max hist| within lookback to reach this threshold before signaling (0=disabled)
+    # min-separation-lookback: 20  # how many bars to scan for prior peak separation when min-separation > 0
   bollinger-bands:
     length: 20
     multiplier: 2.0

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -55,6 +55,8 @@ indicators:
     slow-length: 13     # (was 26)
     signal-length: 5    # (was 9)
     consecutive-bars: 2 # require 2 consecutive bars of histogram direction before MACD signal counts
+    min-separation: 0.002         # MACD signal only fires after histogram was at least this far from zero (in the prior direction) within the lookback — filters out flat noise
+    min-separation-lookback: 20   # bars to scan for the prior peak separation
   bollinger-bands:
     length: 10          # tighter bands = more entry signals (was 20)
     multiplier: 1.5     # narrower bands (was 2.0)

--- a/sample-scalp-config.yml
+++ b/sample-scalp-config.yml
@@ -47,12 +47,14 @@ indicators:
     upper-limit: 65     # more permissive entry threshold (was 70)
     middle-limit: 50
     lower-limit: 35     # wider entry zone (was 30)
+    smooth-length: 3    # 3-bar SMA smoothing on RSI to reduce flicker on 1m candles
   dema:
     length: 5           # faster DEMA (was 9)
   macd:
     fast-length: 6      # faster MACD (was 12)
     slow-length: 13     # (was 26)
     signal-length: 5    # (was 9)
+    consecutive-bars: 2 # require 2 consecutive bars of histogram direction before MACD signal counts
   bollinger-bands:
     length: 10          # tighter bands = more entry signals (was 20)
     multiplier: 1.5     # narrower bands (was 2.0)
@@ -69,18 +71,38 @@ trailing-stop:
   activation-pct: 0.5   # activate trail earlier (was 1.5%)
   trailing-pct: 0.3     # tight trail from peak (was 1.0%)
 
-# Scalp mode: relaxed entry using scoring instead of all-conditions-must-match
+# Scalp mode: relaxed entry using scoring instead of all-conditions-must-match.
+# This sample turns on most v0.14.0 quality knobs — disable them individually
+# if you want to A/B test the impact of each.
 scalp-mode:
   enabled: true
-  min-score: 3           # need 3 out of 6 bullish signals to enter (RSI, MACD, tendency, Bollinger position, ADX, volume)
-  post-buy-delay: 5      # seconds after fill before monitoring exit (was hardcoded 30s)
-  inter-op-delay: 10     # seconds between completed ops (was hardcoded 60s)
-  require-rsi-exit: false # don't require RSI declining for take-profit
-  sl-cooldown: true      # enable exponential backoff after consecutive SL hits
-  max-consecutive-sl: 2  # start cooldown after 2 consecutive SLs
-  cooldown-base-secs: 60 # base cooldown: 60s → 120s → 240s (capped at 600s)
-  atr-stop-loss: true    # dynamically widen SL based on current volatility
-  atr-multiplier: 1.5    # SL = max(configured, 1.5 × ATR%)
+  min-score: 4              # weighted scoring is on → use a slightly higher bar
+  post-buy-delay: 5         # seconds after fill before monitoring exit
+  inter-op-delay: 10        # seconds between completed ops
+  require-rsi-exit: false   # don't require RSI declining for take-profit
+  sl-cooldown: true         # enable exponential backoff after consecutive SL hits
+  max-consecutive-sl: 2
+  cooldown-base-secs: 60    # base cooldown: 60s → 120s → 240s (capped at 600s)
+  atr-stop-loss: true       # dynamically widen SL based on current volatility
+  atr-multiplier: 1.5       # SL = max(configured, 1.5 × ATR%)
+  # --- v0.14.0 indicator overhaul ---
+  weighted-scoring: true        # MACD/RSI/BB ×2, divergence ×3
+  bb-squeeze-enabled: true      # award a bonus when BB width compresses (energy build-up)
+  bb-squeeze-ratio: 0.85
+  bb-squeeze-window: 20
+  volume-strong-multiplier: 1.5 # bonus when current volume > 1.5 × MA
+  divergence-enabled: true      # ×3 bonus on RSI divergence
+  divergence-lookback: 14
+  divergence-swing-pad: 2
+  fast-trend-gate: true         # accept tendency aligned OR MACD line on correct side of zero
+  tp-atr-multiplier: 1.2        # TP = max(--tp, 1.2 × ATR%) — scales with volatility
+  sl-atr-multiplier: 1.5        # SL = max(--sl, 1.5 × ATR%) — overrides atr-multiplier
+  time-stop-bars: 15            # close stale flat positions after 15 minutes (15 × 1m bars)
+  breakeven-atr-mult: 1.0       # pin SL to entry once peak P&L ≥ 1.0 × ATR%
+  min-atr-pct: 0.05             # skip entries below 0.05% ATR (dead market)
+  max-atr-pct: 3.0              # skip entries above 3.0% ATR (chaotic spike)
+  macd-peak-exit: true          # exit profitable trade when MACD histogram rolls over
+  recent-extreme-bars: 30       # block BULL entries within 0.1×ATR of last 30-bar high (BEAR mirror)
 
 # AI — disabled by default for scalp mode to avoid adding LLM latency to fast entry/exit paths.
 # Enable only if slower decisions are acceptable and you want explicit AI approval before entries.

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -274,7 +274,7 @@ func bearTradeLoop(
 
 				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
 				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-				macdOk := hist < 0 && hist < prevHist
+				macdOk := hist < prevHist
 				if macdOk {
 					score++
 				}

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -161,7 +161,7 @@ func bearTradeLoop(
 			// indicators
 			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
 			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length)
+			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
 			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
 			if err != nil {
@@ -260,70 +260,28 @@ func bearTradeLoop(
 			// when to sell (bear entry) — scalp mode uses scoring; classic mode requires all conditions
 			var shouldSell bool
 			if cfg.ScalpMode.Enabled {
-				score := 0
-				var conditions []entryCondition
-
-				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
-				if rsiOk {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("RSI %.1f > %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
-					Met:  rsiOk,
+				eval := evaluateScalp(scalpEvalInput{
+					IsBull: false, Cfg: cfg,
+					Closes: ohlcv.Closes, RSI: rsi,
+					MACDLine: macdLine, SignalLine: signalLine,
+					BB: bb, Tendency: tendency,
+					ADXStrong: adxStrong, ADXVal: adxVal,
+					CurrentVolume: currentVolume, AvgVolume: avgVolume,
+					ATRVal: atrVal, Price: price,
 				})
-
-				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
-				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-				macdOk := hist < prevHist
-				if macdOk {
-					score++
+				if eval.RegimeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Regime gate[-] %s — skipping BEAR entry", eval.RegimeReason))
+					time.Sleep(refreshInterval)
+					continue
 				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("MACD histogram falling (%.6f < %.6f)", hist, prevHist),
-					Met:  macdOk,
-				})
-
-				tendOk := tendency == "down"
-				if tendOk {
-					score++
+				if eval.ExtremeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Recent-extreme gate[-] %s — skipping BEAR entry", eval.ExtremeReason))
+					time.Sleep(refreshInterval)
+					continue
 				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Tendency %s = down", tendency),
-					Met:  tendOk,
-				})
-
-				bbOk := distanceToUpper < distanceToLower
-				if bbOk {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower),
-					Met:  bbOk,
-				})
-
-				if adxStrong {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold),
-					Met:  adxStrong,
-				})
-
-				if volumeConfirmed {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume),
-					Met:  volumeConfirmed,
-				})
-
-				minScore := cfg.ScalpMode.MinScore
-				if minScore <= 0 {
-					minScore = 3
-				}
-				shouldSell = score >= minScore && aiApproved
+				shouldSell = eval.Score >= eval.MinScore && aiApproved
 				if shouldSell {
-					logEntryConditions(dash, "BEAR", conditions, score, 6, minScore, true)
+					logEntryConditions(dash, "BEAR", eval.Conditions, eval.Score, eval.MaxScore, eval.MinScore, true)
 					if !aiApproved {
 						dash.LogInfo("  [red]✗[-] AI approval")
 					}
@@ -392,6 +350,9 @@ func bearTradeLoop(
 		lowestPrice := sellPrice
 		sellProceeds := sellPrice * qty
 		exitType := "" // tracks how position was closed: "tp", "ts", "sl"
+		barsSinceEntry := 0
+		peakPnL := 0.0
+		breakevenActive := false
 
 		for {
 			ohlcv, err := exchange.GetHistoricalOHLCV(client, ticker, interval, period)
@@ -409,11 +370,16 @@ func bearTradeLoop(
 
 			price := ohlcv.Closes[len(ohlcv.Closes)-1]
 			prevPrice := ohlcv.Closes[len(ohlcv.Closes)-2]
-			rsi := indicator.CalculateRSI(rsiprices, cfg.Indicators.Rsi.Length)
+			rsi := indicator.CalculateSmoothedRSI(rsiprices, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
+			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 			dash.UpdatePrice(price, prevPrice, roundPrice)
 
 			// update indicators with P&L
 			pnl := (sellPrice - price) / sellPrice * 100
+			if pnl > peakPnL {
+				peakPnL = pnl
+			}
+			barsSinceEntry++
 			var atrVal float64
 			if cfg.Indicators.Atr.Period > 0 {
 				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
@@ -467,25 +433,30 @@ func bearTradeLoop(
 				}
 			}
 
-			// ATR-based dynamic stop-loss: use max(configuredSL, atrMultiplier × ATR%)
-			effectiveSL := stopLoss
-			if cfg.ScalpMode.ATRStopLoss && cfg.Indicators.Atr.Period > 0 {
-				atr := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-				if len(atr) > 0 {
-					atrMultiplier := cfg.ScalpMode.ATRMultiplier
-					if atrMultiplier <= 0 {
-						atrMultiplier = 1.5
-					}
-					atrPct := (atr[len(atr)-1] / price) * atrMultiplier * 100
-					if atrPct > effectiveSL {
-						dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
-							stopLoss, atrPct, atr[len(atr)-1], price))
-						effectiveSL = atrPct
-					}
+			// ATR-aware effective TP/SL (covers ATRStopLoss + TP/SL ATR multipliers)
+			effectiveTP, effectiveSL := effectiveTPAndSL(cfg, takeProfit, stopLoss, atrVal, price)
+			if effectiveSL > stopLoss {
+				dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
+					stopLoss, effectiveSL, atrVal, price))
+			}
+
+			// Break-even: once peak P&L >= BreakevenATRMult × ATR%, pin SL to entry price
+			if cfg.ScalpMode.BreakevenATRMult > 0 && atrVal > 0 && !breakevenActive {
+				atrPct := (atrVal / sellPrice) * 100
+				if peakPnL >= cfg.ScalpMode.BreakevenATRMult*atrPct {
+					breakevenActive = true
+					dash.LogInfo(fmt.Sprintf("[lime]BREAK-EVEN[-] peak P&L %.2f%% ≥ %.1f×ATR%% (%.2f%%): SL pinned to entry %.*f",
+						peakPnL, cfg.ScalpMode.BreakevenATRMult, atrPct, roundPrice, sellPrice))
+				}
+			}
+			if breakevenActive {
+				// pin stop-loss tolerance to zero (entry price acts as ceiling for bear)
+				if effectiveSL > 0 {
+					effectiveSL = 0
 				}
 			}
 
-			// stop loss: price goes UP (using effective SL which may be ATR-widened)
+			// stop loss: price goes UP (using effective SL which may be ATR-widened or break-even-pinned)
 			stopLossPrice := sellPrice * (1 + effectiveSL/100)
 			if price >= stopLossPrice {
 				dash.SetPhase("STOP LOSS")
@@ -514,7 +485,58 @@ func bearTradeLoop(
 			}
 
 			// take profit with AI exit confirmation
-			profitPrice := sellPrice * (1 - takeProfit/100)
+			profitPrice := sellPrice * (1 - effectiveTP/100)
+
+			// Time-stop: exit flat positions that have lingered too long
+			if cfg.ScalpMode.TimeStopBars > 0 && barsSinceEntry >= cfg.ScalpMode.TimeStopBars && pnl >= 0 && price > profitPrice {
+				dash.SetPhase("TIME STOP")
+				dash.LogInfo(fmt.Sprintf("[yellow]Time-stop triggered:[-] %d bars since entry, P&L %+.2f%% (TP not reached)", barsSinceEntry, pnl))
+				buyBackFactor := 1 - cfg.BuyBackBuffer()/100
+				buyBackQty := indicator.RoundFloat((sellProceeds*buyBackFactor)/price, roundAmount)
+				buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
+				if err != nil {
+					dash.LogError(fmt.Sprintf("Time-stop MARKET BUY failed: %v", err))
+					return
+				}
+				buyOrder := reflect.ValueOf(buy).Elem()
+				orderId := buyOrder.FieldByName("OrderId").Int()
+				dash.LogOrder(fmt.Sprintf("[yellow::b]TIME-STOP MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+					buyBackQty, scoin, roundPrice, price, dcoin, pnl))
+				if !waitOrderFilled(dash, ticker, orderId, "[yellow::b]TIME-STOP MARKET BUY[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Time-stop BUY did not fill; continuing buy-back monitoring[-]")
+					dash.SetPhase("MONITORING BUY-BACK")
+					time.Sleep(refreshInterval)
+					continue
+				}
+				exitType = "ts"
+				break
+			}
+
+			// MACD-peak exit: lock gains when histogram rolls over in profit
+			if pnl > 0 && shouldMACDPeakExit(cfg, macdLine, signalLine, false, pnl) {
+				dash.SetPhase("MACD PEAK EXIT")
+				dash.LogInfo(fmt.Sprintf("[fuchsia]MACD-peak exit:[-] histogram rolling over while in profit (P&L %+.2f%%)", pnl))
+				buyBackFactor := 1 - cfg.BuyBackBuffer()/100
+				buyBackQty := indicator.RoundFloat((sellProceeds*buyBackFactor)/price, roundAmount)
+				buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
+				if err != nil {
+					dash.LogError(fmt.Sprintf("MACD-peak MARKET BUY failed: %v", err))
+					return
+				}
+				buyOrder := reflect.ValueOf(buy).Elem()
+				orderId := buyOrder.FieldByName("OrderId").Int()
+				dash.LogOrder(fmt.Sprintf("[fuchsia::b]MACD-PEAK MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+					buyBackQty, scoin, roundPrice, price, dcoin, pnl))
+				if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]MACD-PEAK MARKET BUY[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]MACD-peak BUY did not fill; continuing buy-back monitoring[-]")
+					dash.SetPhase("MONITORING BUY-BACK")
+					time.Sleep(refreshInterval)
+					continue
+				}
+				exitType = "tp"
+				break
+			}
+
 			var aiBuyApproved = true
 			if price <= profitPrice && aiOrch != nil {
 				snapshot := &ai.TechnicalSnapshot{
@@ -537,7 +559,7 @@ func bearTradeLoop(
 				dash.SetPhase("TAKE PROFIT")
 				pnlPct := (sellPrice - price) / sellPrice * 100
 				dash.LogInfo(fmt.Sprintf("[green]Take-profit triggered:[-] price %.*f <= TP %.*f (sell %.*f, TP %.2f%%, P&L %+.2f%%)",
-					roundPrice, price, roundPrice, profitPrice, roundPrice, sellPrice, takeProfit, pnlPct))
+					roundPrice, price, roundPrice, profitPrice, roundPrice, sellPrice, effectiveTP, pnlPct))
 				dash.LogInfo(fmt.Sprintf("  [green]✓[-] RSI exit ok (RSI rising=%v, scalp bypass=%v)", rsiRising, cfg.ScalpMode.Enabled && !cfg.ScalpMode.RequireRSIExit))
 				if aiOrch != nil {
 					dash.LogInfo(fmt.Sprintf("  [green]✓[-] AI buy-back approved"))

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -160,7 +160,7 @@ func bullTradeLoop(
 			// indicators
 			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
 			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length)
+			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
 			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
 			if err != nil {
@@ -259,70 +259,28 @@ func bullTradeLoop(
 			// when to buy — scalp mode uses scoring; classic mode requires all conditions
 			var shouldBuy bool
 			if cfg.ScalpMode.Enabled {
-				score := 0
-				var conditions []entryCondition
-
-				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
-				if rsiOk {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("RSI %.1f < %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
-					Met:  rsiOk,
+				eval := evaluateScalp(scalpEvalInput{
+					IsBull: true, Cfg: cfg,
+					Closes: ohlcv.Closes, RSI: rsi,
+					MACDLine: macdLine, SignalLine: signalLine,
+					BB: bb, Tendency: tendency,
+					ADXStrong: adxStrong, ADXVal: adxVal,
+					CurrentVolume: currentVolume, AvgVolume: avgVolume,
+					ATRVal: atrVal, Price: price,
 				})
-
-				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
-				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-				macdOk := hist > prevHist
-				if macdOk {
-					score++
+				if eval.RegimeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Regime gate[-] %s — skipping BULL entry", eval.RegimeReason))
+					time.Sleep(refreshInterval)
+					continue
 				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("MACD histogram rising (%.6f > %.6f)", hist, prevHist),
-					Met:  macdOk,
-				})
-
-				tendOk := tendency == "up"
-				if tendOk {
-					score++
+				if eval.ExtremeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Recent-extreme gate[-] %s — skipping BULL entry", eval.ExtremeReason))
+					time.Sleep(refreshInterval)
+					continue
 				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Tendency %s = up", tendency),
-					Met:  tendOk,
-				})
-
-				bbOk := distanceToLower < distanceToUpper
-				if bbOk {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper),
-					Met:  bbOk,
-				})
-
-				if adxStrong {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold),
-					Met:  adxStrong,
-				})
-
-				if volumeConfirmed {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume),
-					Met:  volumeConfirmed,
-				})
-
-				minScore := cfg.ScalpMode.MinScore
-				if minScore <= 0 {
-					minScore = 3
-				}
-				shouldBuy = score >= minScore && aiApproved
+				shouldBuy = eval.Score >= eval.MinScore && aiApproved
 				if shouldBuy {
-					logEntryConditions(dash, "BULL", conditions, score, 6, minScore, true)
+					logEntryConditions(dash, "BULL", eval.Conditions, eval.Score, eval.MaxScore, eval.MinScore, true)
 					if !aiApproved {
 						dash.LogInfo("  [red]✗[-] AI approval")
 					}
@@ -390,6 +348,9 @@ func bullTradeLoop(
 		dash.SetPhase("MONITORING SELL")
 		highestPrice := buyPrice
 		exitType := "" // tracks how position was closed: "tp", "ts", "sl"
+		barsSinceEntry := 0
+		peakPnL := 0.0
+		breakevenActive := false
 
 		for {
 			ohlcv, err := exchange.GetHistoricalOHLCV(client, ticker, interval, period)
@@ -407,11 +368,16 @@ func bullTradeLoop(
 
 			price := ohlcv.Closes[len(ohlcv.Closes)-1]
 			prevPrice := ohlcv.Closes[len(ohlcv.Closes)-2]
-			rsi := indicator.CalculateRSI(rsiprices, cfg.Indicators.Rsi.Length)
+			rsi := indicator.CalculateSmoothedRSI(rsiprices, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
+			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 			dash.UpdatePrice(price, prevPrice, roundPrice)
 
 			// update indicators panel with sell-phase data
 			pnl := (price - buyPrice) / buyPrice * 100
+			if pnl > peakPnL {
+				peakPnL = pnl
+			}
+			barsSinceEntry++
 			var atrVal float64
 			if cfg.Indicators.Atr.Period > 0 {
 				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
@@ -459,25 +425,30 @@ func bullTradeLoop(
 				}
 			}
 
-			// ATR-based dynamic stop-loss: use max(configuredSL, atrMultiplier × ATR%)
-			effectiveSL := stopLoss
-			if cfg.ScalpMode.ATRStopLoss && cfg.Indicators.Atr.Period > 0 {
-				atr := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-				if len(atr) > 0 {
-					atrMultiplier := cfg.ScalpMode.ATRMultiplier
-					if atrMultiplier <= 0 {
-						atrMultiplier = 1.5
-					}
-					atrPct := (atr[len(atr)-1] / price) * atrMultiplier * 100
-					if atrPct > effectiveSL {
-						dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
-							stopLoss, atrPct, atr[len(atr)-1], price))
-						effectiveSL = atrPct
-					}
+			// ATR-aware effective TP/SL (covers ATRStopLoss + TP/SL ATR multipliers)
+			effectiveTP, effectiveSL := effectiveTPAndSL(cfg, takeProfit, stopLoss, atrVal, price)
+			if effectiveSL > stopLoss {
+				dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
+					stopLoss, effectiveSL, atrVal, price))
+			}
+
+			// Break-even: once peak P&L >= BreakevenATRMult × ATR%, pin SL to entry price
+			if cfg.ScalpMode.BreakevenATRMult > 0 && atrVal > 0 && !breakevenActive {
+				atrPct := (atrVal / buyPrice) * 100
+				if peakPnL >= cfg.ScalpMode.BreakevenATRMult*atrPct {
+					breakevenActive = true
+					dash.LogInfo(fmt.Sprintf("[lime]BREAK-EVEN[-] peak P&L %.2f%% ≥ %.1f×ATR%% (%.2f%%): SL pinned to entry %.*f",
+						peakPnL, cfg.ScalpMode.BreakevenATRMult, atrPct, roundPrice, buyPrice))
+				}
+			}
+			if breakevenActive {
+				// pin stop-loss tolerance to zero (entry price acts as floor)
+				if effectiveSL > 0 {
+					effectiveSL = 0
 				}
 			}
 
-			// fixed stop loss (using effective SL which may be ATR-widened)
+			// fixed stop loss (using effective SL which may be ATR-widened or break-even-pinned)
 			stopLossPrice := buyPrice * (1 - effectiveSL/100)
 			if price <= stopLossPrice {
 				dash.SetPhase("STOP LOSS")
@@ -504,7 +475,54 @@ func bullTradeLoop(
 			}
 
 			// take profit with AI exit confirmation
-			profitPrice := buyPrice * (1 + takeProfit/100)
+			profitPrice := buyPrice * (1 + effectiveTP/100)
+
+			// Time-stop: exit flat positions that have lingered too long
+			if cfg.ScalpMode.TimeStopBars > 0 && barsSinceEntry >= cfg.ScalpMode.TimeStopBars && pnl >= 0 && price < profitPrice {
+				dash.SetPhase("TIME STOP")
+				dash.LogInfo(fmt.Sprintf("[yellow]Time-stop triggered:[-] %d bars since entry, P&L %+.2f%% (TP not reached)", barsSinceEntry, pnl))
+				sell, err := TradeMarketSell(symbol, indicator.RoundFloat(qty*0.998, roundAmount), price, roundPrice)
+				if err != nil {
+					dash.LogError(fmt.Sprintf("Time-stop MARKET SELL failed: %v", err))
+					return
+				}
+				sellOrder := reflect.ValueOf(sell).Elem()
+				orderId := sellOrder.FieldByName("OrderId").Int()
+				dash.LogOrder(fmt.Sprintf("[yellow::b]TIME-STOP MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+					qty, scoin, roundPrice, price, dcoin, pnl))
+				if !waitOrderFilled(dash, ticker, orderId, "[yellow::b]TIME-STOP MARKET SELL[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]Time-stop SELL did not fill; continuing exit monitoring[-]")
+					dash.SetPhase("MONITORING SELL")
+					time.Sleep(refreshInterval)
+					continue
+				}
+				exitType = "ts"
+				break
+			}
+
+			// MACD-peak exit: lock gains when histogram rolls over in profit
+			if pnl > 0 && shouldMACDPeakExit(cfg, macdLine, signalLine, true, pnl) {
+				dash.SetPhase("MACD PEAK EXIT")
+				dash.LogInfo(fmt.Sprintf("[fuchsia]MACD-peak exit:[-] histogram rolling over while in profit (P&L %+.2f%%)", pnl))
+				sell, err := TradeMarketSell(symbol, indicator.RoundFloat(qty*0.998, roundAmount), price, roundPrice)
+				if err != nil {
+					dash.LogError(fmt.Sprintf("MACD-peak MARKET SELL failed: %v", err))
+					return
+				}
+				sellOrder := reflect.ValueOf(sell).Elem()
+				orderId := sellOrder.FieldByName("OrderId").Int()
+				dash.LogOrder(fmt.Sprintf("[fuchsia::b]MACD-PEAK MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+					qty, scoin, roundPrice, price, dcoin, pnl))
+				if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]MACD-PEAK MARKET SELL[-] filled!", refreshInterval, cfg) {
+					dash.LogInfo("[yellow]MACD-peak SELL did not fill; continuing exit monitoring[-]")
+					dash.SetPhase("MONITORING SELL")
+					time.Sleep(refreshInterval)
+					continue
+				}
+				exitType = "tp"
+				break
+			}
+
 			var aiSellApproved = true
 			if price >= profitPrice && aiOrch != nil {
 				snapshot := &ai.TechnicalSnapshot{
@@ -527,7 +545,7 @@ func bullTradeLoop(
 				dash.SetPhase("TAKE PROFIT")
 				pnlPct := (price - buyPrice) / buyPrice * 100
 				dash.LogInfo(fmt.Sprintf("[green]Take-profit triggered:[-] price %.*f >= TP %.*f (buy %.*f, TP %.2f%%, P&L %+.2f%%)",
-					roundPrice, price, roundPrice, profitPrice, roundPrice, buyPrice, takeProfit, pnlPct))
+					roundPrice, price, roundPrice, profitPrice, roundPrice, buyPrice, effectiveTP, pnlPct))
 				dash.LogInfo(fmt.Sprintf("  [green]✓[-] RSI exit ok (RSI declining=%v, scalp bypass=%v)", rsiDeclining, cfg.ScalpMode.Enabled && !cfg.ScalpMode.RequireRSIExit))
 				if aiOrch != nil {
 					dash.LogInfo(fmt.Sprintf("  [green]✓[-] AI sell approved"))

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -273,7 +273,7 @@ func bullTradeLoop(
 
 				hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
 				prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-				macdOk := hist > 0 && hist > prevHist
+				macdOk := hist > prevHist
 				if macdOk {
 					score++
 				}

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -513,7 +513,7 @@ operationLoop:
 
 					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
 					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-					macdOk := hist > 0 && hist > prevHist
+					macdOk := hist > prevHist
 					if macdOk {
 						score++
 					}
@@ -551,7 +551,7 @@ operationLoop:
 
 					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
 					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-					macdOk := hist < 0 && hist < prevHist
+					macdOk := hist < prevHist
 					if macdOk {
 						score++
 					}

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -216,7 +216,7 @@ operationLoop:
 
 				// Show indicators while waiting
 				dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
-				rsi := indicator.CalculateRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length)
+				rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
 				macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 				bb, bbErr := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
 				if bbErr == nil && len(rsi) > 0 && len(macdLine) > 1 && len(dema) > 0 {
@@ -377,7 +377,7 @@ operationLoop:
 			// indicators
 			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
 			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length)
+			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
 			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
 			if err != nil {
@@ -498,114 +498,32 @@ operationLoop:
 			// Entry conditions
 			var shouldEnter bool
 			if cfg.ScalpMode.Enabled {
-				score := 0
-				var conditions []entryCondition
-
-				if isBull {
-					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
-					if rsiOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("RSI %.1f < %d (lower limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit),
-						Met:  rsiOk,
-					})
-
-					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
-					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-					macdOk := hist > prevHist
-					if macdOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("MACD histogram rising (%.6f > %.6f)", hist, prevHist),
-						Met:  macdOk,
-					})
-
-					tendOk := tendency == "up"
-					if tendOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("Tendency %s = up", tendency),
-						Met:  tendOk,
-					})
-
-					bbOk := distanceToLower < distanceToUpper
-					if bbOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper),
-						Met:  bbOk,
-					})
-				} else {
-					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
-					if rsiOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("RSI %.1f > %d (upper limit)", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit),
-						Met:  rsiOk,
-					})
-
-					hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
-					prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-					macdOk := hist < prevHist
-					if macdOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("MACD histogram falling (%.6f < %.6f)", hist, prevHist),
-						Met:  macdOk,
-					})
-
-					tendOk := tendency == "down"
-					if tendOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("Tendency %s = down", tendency),
-						Met:  tendOk,
-					})
-
-					bbOk := distanceToUpper < distanceToLower
-					if bbOk {
-						score++
-					}
-					conditions = append(conditions, entryCondition{
-						Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower),
-						Met:  bbOk,
-					})
-				}
-
-				if adxStrong {
-					score++
-				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold),
-					Met:  adxStrong,
+				eval := evaluateScalp(scalpEvalInput{
+					IsBull: isBull, Cfg: cfg,
+					Closes: ohlcv.Closes, RSI: rsi,
+					MACDLine: macdLine, SignalLine: signalLine,
+					BB: bb, Tendency: tendency,
+					ADXStrong: adxStrong, ADXVal: adxVal,
+					CurrentVolume: currentVolume, AvgVolume: avgVolume,
+					ATRVal: atrVal, Price: price,
 				})
-
-				if volumeConfirmed {
-					score++
+				mode := "BULL"
+				if !isBull {
+					mode = "BEAR"
 				}
-				conditions = append(conditions, entryCondition{
-					Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume),
-					Met:  volumeConfirmed,
-				})
-
-				minScore := cfg.ScalpMode.MinScore
-				if minScore <= 0 {
-					minScore = 3
+				if eval.RegimeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Regime gate[-] %s — skipping %s entry", eval.RegimeReason, mode))
+					time.Sleep(refreshInterval)
+					continue
 				}
-				shouldEnter = score >= minScore && aiApproved
+				if eval.ExtremeBlocked {
+					dash.LogInfo(fmt.Sprintf("[yellow]Recent-extreme gate[-] %s — skipping %s entry", eval.ExtremeReason, mode))
+					time.Sleep(refreshInterval)
+					continue
+				}
+				shouldEnter = eval.Score >= eval.MinScore && aiApproved
 				if shouldEnter {
-					mode := "BULL"
-					if !isBull {
-						mode = "BEAR"
-					}
-					logEntryConditions(dash, mode, conditions, score, 6, minScore, true)
+					logEntryConditions(dash, mode, eval.Conditions, eval.Score, eval.MaxScore, eval.MinScore, true)
 					if !aiApproved {
 						dash.LogInfo("  [red]✗[-] AI approval")
 					}
@@ -736,6 +654,9 @@ operationLoop:
 		if isBull {
 			dash.SetPhase("MONITORING SELL")
 			highestPrice := entryPrice
+			barsSinceEntry := 0
+			peakPnL := 0.0
+			breakevenActive := false
 
 			for {
 				ohlcv, err := exchange.GetHistoricalOHLCV(client, ticker, interval, period)
@@ -753,10 +674,15 @@ operationLoop:
 
 				price := ohlcv.Closes[len(ohlcv.Closes)-1]
 				prevPrice := ohlcv.Closes[len(ohlcv.Closes)-2]
-				rsi := indicator.CalculateRSI(rsiprices, cfg.Indicators.Rsi.Length)
+				rsi := indicator.CalculateSmoothedRSI(rsiprices, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
+				macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 				dash.UpdatePrice(price, prevPrice, roundPrice)
 
 				pnl := (price - entryPrice) / entryPrice * 100
+				if pnl > peakPnL {
+					peakPnL = pnl
+				}
+				barsSinceEntry++
 				var atrVal float64
 				if cfg.Indicators.Atr.Period > 0 {
 					atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
@@ -804,22 +730,24 @@ operationLoop:
 					}
 				}
 
-				// ATR-based dynamic stop-loss
-				effectiveSL := stopLoss
-				if cfg.ScalpMode.ATRStopLoss && cfg.Indicators.Atr.Period > 0 {
-					atr := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-					if len(atr) > 0 {
-						atrMultiplier := cfg.ScalpMode.ATRMultiplier
-						if atrMultiplier <= 0 {
-							atrMultiplier = 1.5
-						}
-						atrPct := (atr[len(atr)-1] / price) * atrMultiplier * 100
-						if atrPct > effectiveSL {
-							dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
-								stopLoss, atrPct, atr[len(atr)-1], price))
-							effectiveSL = atrPct
-						}
+				// ATR-aware effective TP/SL (covers ATRStopLoss + TP/SL ATR multipliers)
+				effectiveTP, effectiveSL := effectiveTPAndSL(cfg, takeProfit, stopLoss, atrVal, price)
+				if effectiveSL > stopLoss {
+					dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
+						stopLoss, effectiveSL, atrVal, price))
+				}
+
+				// Break-even: once peak P&L >= BreakevenATRMult × ATR%, pin SL to entry price
+				if cfg.ScalpMode.BreakevenATRMult > 0 && atrVal > 0 && !breakevenActive {
+					atrPct := (atrVal / entryPrice) * 100
+					if peakPnL >= cfg.ScalpMode.BreakevenATRMult*atrPct {
+						breakevenActive = true
+						dash.LogInfo(fmt.Sprintf("[lime]BREAK-EVEN[-] peak P&L %.2f%% ≥ %.1f×ATR%% (%.2f%%): SL pinned to entry %.*f",
+							peakPnL, cfg.ScalpMode.BreakevenATRMult, atrPct, roundPrice, entryPrice))
 					}
+				}
+				if breakevenActive && effectiveSL > 0 {
+					effectiveSL = 0
 				}
 
 				// fixed stop loss
@@ -849,7 +777,54 @@ operationLoop:
 				}
 
 				// take profit
-				profitPrice := entryPrice * (1 + takeProfit/100)
+				profitPrice := entryPrice * (1 + effectiveTP/100)
+
+				// Time-stop: exit flat positions that have lingered too long
+				if cfg.ScalpMode.TimeStopBars > 0 && barsSinceEntry >= cfg.ScalpMode.TimeStopBars && pnl >= 0 && price < profitPrice {
+					dash.SetPhase("TIME STOP")
+					dash.LogInfo(fmt.Sprintf("[yellow]Time-stop triggered:[-] %d bars since entry, P&L %+.2f%% (TP not reached)", barsSinceEntry, pnl))
+					sell, err := TradeMarketSell(symbol, indicator.RoundFloat(qty*0.998, roundAmount), price, roundPrice)
+					if err != nil {
+						dash.LogError(fmt.Sprintf("Time-stop MARKET SELL failed: %v", err))
+						return
+					}
+					sellOrder := reflect.ValueOf(sell).Elem()
+					orderId := sellOrder.FieldByName("OrderId").Int()
+					dash.LogOrder(fmt.Sprintf("[yellow::b]TIME-STOP MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+						qty, scoin, roundPrice, price, dcoin, pnl))
+					if !waitOrderFilled(dash, ticker, orderId, "[yellow::b]TIME-STOP MARKET SELL[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Time-stop SELL did not fill; continuing exit monitoring[-]")
+						dash.SetPhase("MONITORING SELL")
+						time.Sleep(refreshInterval)
+						continue
+					}
+					exitType = "ts"
+					break
+				}
+
+				// MACD-peak exit
+				if pnl > 0 && shouldMACDPeakExit(cfg, macdLine, signalLine, true, pnl) {
+					dash.SetPhase("MACD PEAK EXIT")
+					dash.LogInfo(fmt.Sprintf("[fuchsia]MACD-peak exit:[-] histogram rolling over while in profit (P&L %+.2f%%)", pnl))
+					sell, err := TradeMarketSell(symbol, indicator.RoundFloat(qty*0.998, roundAmount), price, roundPrice)
+					if err != nil {
+						dash.LogError(fmt.Sprintf("MACD-peak MARKET SELL failed: %v", err))
+						return
+					}
+					sellOrder := reflect.ValueOf(sell).Elem()
+					orderId := sellOrder.FieldByName("OrderId").Int()
+					dash.LogOrder(fmt.Sprintf("[fuchsia::b]MACD-PEAK MARKET SELL[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+						qty, scoin, roundPrice, price, dcoin, pnl))
+					if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]MACD-PEAK MARKET SELL[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]MACD-peak SELL did not fill; continuing exit monitoring[-]")
+						dash.SetPhase("MONITORING SELL")
+						time.Sleep(refreshInterval)
+						continue
+					}
+					exitType = "tp"
+					break
+				}
+
 				var aiSellApproved = true
 				if price >= profitPrice && aiOrch != nil {
 					snapshot := &ai.TechnicalSnapshot{
@@ -872,7 +847,7 @@ operationLoop:
 					dash.SetPhase("TAKE PROFIT")
 					pnlPct := (price - entryPrice) / entryPrice * 100
 					dash.LogInfo(fmt.Sprintf("[green]Take-profit triggered:[-] price %.*f >= TP %.*f (buy %.*f, TP %.2f%%, P&L %+.2f%%)",
-						roundPrice, price, roundPrice, profitPrice, roundPrice, entryPrice, takeProfit, pnlPct))
+						roundPrice, price, roundPrice, profitPrice, roundPrice, entryPrice, effectiveTP, pnlPct))
 					dash.LogInfo(fmt.Sprintf("  [green]✓[-] RSI exit ok (RSI declining=%v, scalp bypass=%v)", rsiDeclining, cfg.ScalpMode.Enabled && !cfg.ScalpMode.RequireRSIExit))
 					if aiOrch != nil {
 						dash.LogInfo(fmt.Sprintf("  [green]✓[-] AI sell approved"))
@@ -903,6 +878,9 @@ operationLoop:
 			dash.SetPhase("MONITORING BUY-BACK")
 			lowestPrice := entryPrice
 			sellProceeds := entryPrice * qty
+			barsSinceEntry := 0
+			peakPnL := 0.0
+			breakevenActive := false
 
 			for {
 				ohlcv, err := exchange.GetHistoricalOHLCV(client, ticker, interval, period)
@@ -920,10 +898,15 @@ operationLoop:
 
 				price := ohlcv.Closes[len(ohlcv.Closes)-1]
 				prevPrice := ohlcv.Closes[len(ohlcv.Closes)-2]
-				rsi := indicator.CalculateRSI(rsiprices, cfg.Indicators.Rsi.Length)
+				rsi := indicator.CalculateSmoothedRSI(rsiprices, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
+				macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 				dash.UpdatePrice(price, prevPrice, roundPrice)
 
 				pnl := (entryPrice - price) / entryPrice * 100
+				if pnl > peakPnL {
+					peakPnL = pnl
+				}
+				barsSinceEntry++
 				var atrVal float64
 				if cfg.Indicators.Atr.Period > 0 {
 					atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
@@ -972,22 +955,24 @@ operationLoop:
 					}
 				}
 
-				// ATR-based dynamic stop-loss
-				effectiveSL := stopLoss
-				if cfg.ScalpMode.ATRStopLoss && cfg.Indicators.Atr.Period > 0 {
-					atr := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-					if len(atr) > 0 {
-						atrMultiplier := cfg.ScalpMode.ATRMultiplier
-						if atrMultiplier <= 0 {
-							atrMultiplier = 1.5
-						}
-						atrPct := (atr[len(atr)-1] / price) * atrMultiplier * 100
-						if atrPct > effectiveSL {
-							dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
-								stopLoss, atrPct, atr[len(atr)-1], price))
-							effectiveSL = atrPct
-						}
+				// ATR-aware effective TP/SL (covers ATRStopLoss + TP/SL ATR multipliers)
+				effectiveTP, effectiveSL := effectiveTPAndSL(cfg, takeProfit, stopLoss, atrVal, price)
+				if effectiveSL > stopLoss {
+					dash.LogInfo(fmt.Sprintf("[yellow]ATR-SL[-] widened SL from %.2f%% to %.2f%% (ATR=%.8f, price=%.8f)",
+						stopLoss, effectiveSL, atrVal, price))
+				}
+
+				// Break-even: once peak P&L >= BreakevenATRMult × ATR%, pin SL to entry price
+				if cfg.ScalpMode.BreakevenATRMult > 0 && atrVal > 0 && !breakevenActive {
+					atrPct := (atrVal / entryPrice) * 100
+					if peakPnL >= cfg.ScalpMode.BreakevenATRMult*atrPct {
+						breakevenActive = true
+						dash.LogInfo(fmt.Sprintf("[lime]BREAK-EVEN[-] peak P&L %.2f%% ≥ %.1f×ATR%% (%.2f%%): SL pinned to entry %.*f",
+							peakPnL, cfg.ScalpMode.BreakevenATRMult, atrPct, roundPrice, entryPrice))
 					}
+				}
+				if breakevenActive && effectiveSL > 0 {
+					effectiveSL = 0
 				}
 
 				// stop loss: price goes UP
@@ -1018,7 +1003,56 @@ operationLoop:
 				}
 
 				// take profit
-				profitPrice := entryPrice * (1 - takeProfit/100)
+				profitPrice := entryPrice * (1 - effectiveTP/100)
+
+				// Time-stop: exit flat positions that have lingered too long
+				if cfg.ScalpMode.TimeStopBars > 0 && barsSinceEntry >= cfg.ScalpMode.TimeStopBars && pnl >= 0 && price > profitPrice {
+					dash.SetPhase("TIME STOP")
+					dash.LogInfo(fmt.Sprintf("[yellow]Time-stop triggered:[-] %d bars since entry, P&L %+.2f%% (TP not reached)", barsSinceEntry, pnl))
+					buyBackQty := indicator.RoundFloat(sellProceeds/price, roundAmount)
+					buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
+					if err != nil {
+						dash.LogError(fmt.Sprintf("Time-stop MARKET BUY failed: %v", err))
+						return
+					}
+					buyOrder := reflect.ValueOf(buy).Elem()
+					orderId := buyOrder.FieldByName("OrderId").Int()
+					dash.LogOrder(fmt.Sprintf("[yellow::b]TIME-STOP MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+						buyBackQty, scoin, roundPrice, price, dcoin, pnl))
+					if !waitOrderFilled(dash, ticker, orderId, "[yellow::b]TIME-STOP MARKET BUY[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]Time-stop BUY did not fill; continuing buy-back monitoring[-]")
+						dash.SetPhase("MONITORING BUY-BACK")
+						time.Sleep(refreshInterval)
+						continue
+					}
+					exitType = "ts"
+					break
+				}
+
+				// MACD-peak exit
+				if pnl > 0 && shouldMACDPeakExit(cfg, macdLine, signalLine, false, pnl) {
+					dash.SetPhase("MACD PEAK EXIT")
+					dash.LogInfo(fmt.Sprintf("[fuchsia]MACD-peak exit:[-] histogram rolling over while in profit (P&L %+.2f%%)", pnl))
+					buyBackQty := indicator.RoundFloat(sellProceeds/price, roundAmount)
+					buy, err := TradeMarketBuy(symbol, buyBackQty, price, roundPrice)
+					if err != nil {
+						dash.LogError(fmt.Sprintf("MACD-peak MARKET BUY failed: %v", err))
+						return
+					}
+					buyOrder := reflect.ValueOf(buy).Elem()
+					orderId := buyOrder.FieldByName("OrderId").Int()
+					dash.LogOrder(fmt.Sprintf("[fuchsia::b]MACD-PEAK MARKET BUY[-] %f %s @ [white::b]%.*f[-] %s (P&L %+.2f%%)",
+						buyBackQty, scoin, roundPrice, price, dcoin, pnl))
+					if !waitOrderFilled(dash, ticker, orderId, "[fuchsia::b]MACD-PEAK MARKET BUY[-] filled!", refreshInterval, cfg) {
+						dash.LogInfo("[yellow]MACD-peak BUY did not fill; continuing buy-back monitoring[-]")
+						dash.SetPhase("MONITORING BUY-BACK")
+						time.Sleep(refreshInterval)
+						continue
+					}
+					exitType = "tp"
+					break
+				}
+
 				var aiBuyApproved = true
 				if price <= profitPrice && aiOrch != nil {
 					snapshot := &ai.TechnicalSnapshot{
@@ -1041,7 +1075,7 @@ operationLoop:
 					dash.SetPhase("TAKE PROFIT")
 					pnlPct := (entryPrice - price) / entryPrice * 100
 					dash.LogInfo(fmt.Sprintf("[green]Take-profit triggered:[-] price %.*f <= TP %.*f (sell %.*f, TP %.2f%%, P&L %+.2f%%)",
-						roundPrice, price, roundPrice, profitPrice, roundPrice, entryPrice, takeProfit, pnlPct))
+						roundPrice, price, roundPrice, profitPrice, roundPrice, entryPrice, effectiveTP, pnlPct))
 					dash.LogInfo(fmt.Sprintf("  [green]✓[-] RSI exit ok (RSI rising=%v, scalp bypass=%v)", rsiRising, cfg.ScalpMode.Enabled && !cfg.ScalpMode.RequireRSIExit))
 					if aiOrch != nil {
 						dash.LogInfo(fmt.Sprintf("  [green]✓[-] AI buy-back approved"))

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -117,36 +117,31 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 		return SignalHold
 	}
 	closes := ohlcv.Closes[:i+1]
-	dema := indicator.CalculateDEMA(closes, cfg.Indicators.Dema.Length)
-	rsi := indicator.CalculateRSI(closes, cfg.Indicators.Rsi.Length)
+	rsi := indicator.CalculateSmoothedRSI(closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
 	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
 	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
-	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
+	if err != nil || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
 		return SignalHold
 	}
-	score := 0
-	currentDema := dema[len(dema)-1]
-	lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
-	upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit) {
-		score++
+	var atrVal float64
+	if cfg.Indicators.Atr.Period > 0 {
+		atr := indicator.CalculateATR(ohlcv.Highs[:i+1], ohlcv.Lows[:i+1], closes, cfg.Indicators.Atr.Period)
+		if len(atr) > 0 {
+			atrVal = atr[len(atr)-1]
+		}
 	}
-	hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
-	prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-	if hist > prevHist {
-		score++
+	eval := evaluateScalp(scalpEvalInput{
+		IsBull: true, Cfg: cfg,
+		Closes: closes, RSI: rsi,
+		MACDLine: macdLine, SignalLine: signalLine,
+		BB: bb, Tendency: snapshot.Tendency,
+		ADXStrong: true, // ADX is permissive in the registry/backtest strategy
+		ATRVal:    atrVal, Price: price,
+	})
+	if eval.RegimeBlocked || eval.ExtremeBlocked {
+		return SignalHold
 	}
-	if snapshot.Tendency == "up" {
-		score++
-	}
-	if math.Abs(currentDema-lowerBand) < math.Abs(currentDema-upperBand) {
-		score++
-	}
-	minScore := cfg.ScalpMode.MinScore
-	if minScore <= 0 {
-		minScore = 3
-	}
-	if score >= minScore {
+	if eval.Score >= eval.MinScore {
 		return SignalBuy
 	}
 	return SignalHold

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -133,7 +133,7 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	}
 	hist := macdLine[len(macdLine)-1] - signalLine[len(signalLine)-1]
 	prevHist := macdLine[len(macdLine)-2] - signalLine[len(signalLine)-2]
-	if hist > 0 && hist > prevHist {
+	if hist > prevHist {
 		score++
 	}
 	if snapshot.Tendency == "up" {

--- a/strategy/scalp_helpers.go
+++ b/strategy/scalp_helpers.go
@@ -1,0 +1,313 @@
+package strategy
+
+import (
+	"fmt"
+
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/indicator"
+)
+
+// scalpEvalInput aggregates everything ComputeScalpScore needs to evaluate a
+// scalp entry. All slices are expected to be aligned to the same bar series
+// where possible. The function is tolerant of short slices and indicators
+// that were disabled in config (zero values).
+type scalpEvalInput struct {
+	IsBull        bool
+	Cfg           *config.Config
+	Closes        []float64
+	RSI           []float64
+	MACDLine      []float64
+	SignalLine    []float64
+	BB            indicator.BollingerBands
+	Tendency      string
+	ADXStrong     bool
+	ADXVal        float64
+	CurrentVolume float64
+	AvgVolume     float64
+	ATRVal        float64
+	Price         float64
+}
+
+type scalpEvalResult struct {
+	Score          int
+	MaxScore       int
+	MinScore       int
+	Conditions     []entryCondition
+	RegimeBlocked  bool
+	RegimeReason   string
+	ExtremeBlocked bool
+	ExtremeReason  string
+}
+
+// weight returns the weight to assign to a signal name when weighted scoring
+// is enabled. Unknown names default to 1.
+func scalpWeight(cfg *config.Config, name string) int {
+	if cfg == nil || !cfg.ScalpMode.WeightedScoring {
+		return 1
+	}
+	switch name {
+	case "macd", "rsi", "bb":
+		return 2
+	case "divergence":
+		return 3
+	default:
+		return 1
+	}
+}
+
+// addCondition appends an entryCondition and updates score/total according to
+// the configured weighting.
+func addCondition(res *scalpEvalResult, cfg *config.Config, name, label string, met bool) {
+	w := scalpWeight(cfg, name)
+	res.MaxScore += w
+	if met {
+		res.Score += w
+	}
+	res.Conditions = append(res.Conditions, entryCondition{Name: label, Met: met})
+}
+
+// evaluateScalp computes the full scalp score, condition breakdown and
+// regime/recent-extreme blocking signals.
+func evaluateScalp(in scalpEvalInput) scalpEvalResult {
+	res := scalpEvalResult{}
+	cfg := in.Cfg
+	if cfg == nil || len(in.RSI) == 0 || len(in.MACDLine) < 2 || len(in.SignalLine) < 2 {
+		return res
+	}
+	lastRSI := in.RSI[len(in.RSI)-1]
+	prevRSI := lastRSI
+	if len(in.RSI) >= 2 {
+		prevRSI = in.RSI[len(in.RSI)-2]
+	}
+	prev2RSI := prevRSI
+	if len(in.RSI) >= 3 {
+		prev2RSI = in.RSI[len(in.RSI)-3]
+	}
+
+	// ---- Regime filter (ATR%) ----
+	if in.ATRVal > 0 && in.Price > 0 {
+		atrPct := in.ATRVal / in.Price * 100
+		if cfg.ScalpMode.MinATRPct > 0 && atrPct < cfg.ScalpMode.MinATRPct {
+			res.RegimeBlocked = true
+			res.RegimeReason = fmt.Sprintf("ATR %.3f%% < min %.3f%% (regime too quiet)", atrPct, cfg.ScalpMode.MinATRPct)
+		}
+		if cfg.ScalpMode.MaxATRPct > 0 && atrPct > cfg.ScalpMode.MaxATRPct {
+			res.RegimeBlocked = true
+			res.RegimeReason = fmt.Sprintf("ATR %.3f%% > max %.3f%% (regime too volatile)", atrPct, cfg.ScalpMode.MaxATRPct)
+		}
+	}
+
+	// ---- Recent-extreme guard ----
+	if cfg.ScalpMode.RecentExtremeBars > 0 && len(in.Closes) > cfg.ScalpMode.RecentExtremeBars+1 {
+		high, low := indicator.RecentExtremeLookback(in.Closes, cfg.ScalpMode.RecentExtremeBars)
+		if in.IsBull && in.Price < low {
+			res.ExtremeBlocked = true
+			res.ExtremeReason = fmt.Sprintf("price %.6f below recent %d-bar low %.6f", in.Price, cfg.ScalpMode.RecentExtremeBars, low)
+		}
+		if !in.IsBull && in.Price > high {
+			res.ExtremeBlocked = true
+			res.ExtremeReason = fmt.Sprintf("price %.6f above recent %d-bar high %.6f", in.Price, cfg.ScalpMode.RecentExtremeBars, high)
+		}
+	}
+
+	// ---- 1. RSI (pullback-in-trend default) ----
+	middle := float64(cfg.Indicators.Rsi.MiddleLimit)
+	if middle == 0 {
+		middle = 50
+	}
+	var rsiMet bool
+	var rsiLabel string
+	if in.IsBull {
+		rsiMet = lastRSI < middle && lastRSI > prevRSI && prevRSI > prev2RSI
+		rsiLabel = fmt.Sprintf("RSI pullback rising %.1f<%.0f & rising 2 bars (%.1f,%.1f,%.1f)", lastRSI, middle, prev2RSI, prevRSI, lastRSI)
+	} else {
+		rsiMet = lastRSI > middle && lastRSI < prevRSI && prevRSI < prev2RSI
+		rsiLabel = fmt.Sprintf("RSI pullback falling %.1f>%.0f & falling 2 bars (%.1f,%.1f,%.1f)", lastRSI, middle, prev2RSI, prevRSI, lastRSI)
+	}
+	addCondition(&res, cfg, "rsi", rsiLabel, rsiMet)
+
+	// ---- 2. MACD histogram (anticipatory + optional N consecutive bars) ----
+	consec := cfg.Indicators.Macd.ConsecutiveBars
+	if consec <= 0 {
+		consec = 1
+	}
+	macdMet := histDirectionHolds(in.MACDLine, in.SignalLine, consec, in.IsBull)
+	hist := in.MACDLine[len(in.MACDLine)-1] - in.SignalLine[len(in.SignalLine)-1]
+	prevHist := in.MACDLine[len(in.MACDLine)-2] - in.SignalLine[len(in.SignalLine)-2]
+	dirSym := ">"
+	if !in.IsBull {
+		dirSym = "<"
+	}
+	macdLabel := fmt.Sprintf("MACD histogram %s prev for %d bar(s) (hist=%.6f, prev=%.6f)", dirSym, consec, hist, prevHist)
+	addCondition(&res, cfg, "macd", macdLabel, macdMet)
+
+	// ---- 3. Tendency / fast trend gate ----
+	if cfg.ScalpMode.FastTrendGate {
+		macdNow := in.MACDLine[len(in.MACDLine)-1]
+		fastOk := (in.IsBull && macdNow > 0) || (!in.IsBull && macdNow < 0)
+		fastLabel := fmt.Sprintf("MACD zero-line trend (MACD=%.6f %s 0)", macdNow, dirSym)
+		addCondition(&res, cfg, "tendency", fastLabel, fastOk)
+	} else {
+		expected := "up"
+		if !in.IsBull {
+			expected = "down"
+		}
+		tendOk := in.Tendency == expected
+		addCondition(&res, cfg, "tendency", fmt.Sprintf("Tendency %s = %s", in.Tendency, expected), tendOk)
+	}
+
+	// ---- 4. Bollinger price-touch ----
+	if len(in.BB.LowerBand) > 0 && len(in.BB.UpperBand) > 0 {
+		lower := in.BB.LowerBand[len(in.BB.LowerBand)-1]
+		upper := in.BB.UpperBand[len(in.BB.UpperBand)-1]
+		var bbMet bool
+		var bbLabel string
+		if in.IsBull {
+			bbMet = in.Price <= lower
+			bbLabel = fmt.Sprintf("Price touched lower BB (price=%.6f <= lower=%.6f)", in.Price, lower)
+		} else {
+			bbMet = in.Price >= upper
+			bbLabel = fmt.Sprintf("Price touched upper BB (price=%.6f >= upper=%.6f)", in.Price, upper)
+		}
+		addCondition(&res, cfg, "bb", bbLabel, bbMet)
+	}
+
+	// ---- 5. ADX ----
+	addCondition(&res, cfg, "adx",
+		fmt.Sprintf("ADX strong (%.1f > %d)", in.ADXVal, cfg.Indicators.Adx.Threshold),
+		in.ADXStrong)
+
+	// ---- 6. Volume (with strong multiplier) ----
+	volMult := cfg.ScalpMode.VolumeStrongMultiplier
+	if volMult <= 0 {
+		volMult = 1.0
+	}
+	volMet := in.AvgVolume == 0 || in.CurrentVolume > in.AvgVolume*volMult
+	addCondition(&res, cfg, "volume",
+		fmt.Sprintf("Volume strong (%.0f > %.1fx avg %.0f)", in.CurrentVolume, volMult, in.AvgVolume),
+		volMet)
+
+	// ---- 7. BB squeeze bonus (opt-in) ----
+	if cfg.ScalpMode.BBSqueezeEnabled {
+		ratio := cfg.ScalpMode.BBSqueezeRatio
+		if ratio <= 0 {
+			ratio = 0.6
+		}
+		window := cfg.ScalpMode.BBSqueezeWindow
+		if window <= 0 {
+			window = 20
+		}
+		actual := indicator.BollingerWidthRatio(in.BB, window)
+		squeezed := actual > 0 && actual < ratio
+		addCondition(&res, cfg, "squeeze",
+			fmt.Sprintf("BB squeeze (width/avg %.2f < %.2f over %d bars)", actual, ratio, window),
+			squeezed)
+	}
+
+	// ---- 8. Divergence bonus (opt-in, weight=3 in weighted mode) ----
+	if cfg.ScalpMode.DivergenceEnabled && len(in.RSI) > 0 && len(in.Closes) > 0 {
+		lookback := cfg.ScalpMode.DivergenceLookback
+		if lookback <= 0 {
+			lookback = 30
+		}
+		pad := cfg.ScalpMode.DivergenceSwingPad
+		if pad <= 0 {
+			pad = 2
+		}
+		// Align closes to RSI tail length (RSI is shorter by ~period).
+		rsiLen := len(in.RSI)
+		clo := in.Closes
+		if len(clo) > rsiLen {
+			clo = clo[len(clo)-rsiLen:]
+		}
+		var divMet bool
+		if in.IsBull {
+			divMet = indicator.BullishDivergence(clo, in.RSI, lookback, pad)
+		} else {
+			divMet = indicator.BearishDivergence(clo, in.RSI, lookback, pad)
+		}
+		addCondition(&res, cfg, "divergence",
+			fmt.Sprintf("%s divergence over %d bars", map[bool]string{true: "Bullish", false: "Bearish"}[in.IsBull], lookback),
+			divMet)
+	}
+
+	// ---- min-score ----
+	res.MinScore = cfg.ScalpMode.MinScore
+	if res.MinScore <= 0 {
+		res.MinScore = 3
+	}
+
+	return res
+}
+
+// histDirectionHolds returns true when the MACD histogram has been moving in
+// the trade direction for the last `n` bars (n>=1). For bull this means each
+// bar's histogram is strictly greater than the previous bar; for bear, less.
+func histDirectionHolds(macd, signal []float64, n int, isBull bool) bool {
+	if n < 1 || len(macd) < n+1 || len(signal) < n+1 {
+		return false
+	}
+	for k := 0; k < n; k++ {
+		idx := len(macd) - 1 - k
+		hist := macd[idx] - signal[idx]
+		prev := macd[idx-1] - signal[idx-1]
+		if isBull && !(hist > prev) {
+			return false
+		}
+		if !isBull && !(hist < prev) {
+			return false
+		}
+	}
+	return true
+}
+
+// effectiveTPAndSL computes take-profit / stop-loss percentages, applying
+// ATR-based overrides when configured. The caller passes the user's --tp/--sl
+// arguments; this function returns the values to actually use.
+//
+// Precedence:
+//
+//	TPATRMultiplier > 0 → TP = ATR% × multiplier (overrides --tp)
+//	SLATRMultiplier > 0 → SL = ATR% × multiplier (overrides --sl)
+//	ATRStopLoss flag    → SL = max(SL, ATR% × ATRMultiplier)  (existing floor behaviour)
+func effectiveTPAndSL(cfg *config.Config, tp, sl, atr, price float64) (effTP, effSL float64) {
+	effTP, effSL = tp, sl
+	if cfg == nil || atr <= 0 || price <= 0 {
+		return
+	}
+	atrPct := atr / price * 100
+	if cfg.ScalpMode.TPATRMultiplier > 0 {
+		effTP = atrPct * cfg.ScalpMode.TPATRMultiplier
+	}
+	if cfg.ScalpMode.SLATRMultiplier > 0 {
+		effSL = atrPct * cfg.ScalpMode.SLATRMultiplier
+	} else if cfg.ScalpMode.ATRStopLoss {
+		m := cfg.ScalpMode.ATRMultiplier
+		if m <= 0 {
+			m = 1.5
+		}
+		floor := atrPct * m
+		if floor > effSL {
+			effSL = floor
+		}
+	}
+	return
+}
+
+// shouldMACDPeakExit returns true when the bot is in profit AND the MACD
+// histogram has rolled over against the trade direction (peak/trough printed
+// on the previous bar). This anticipates the reversal before TP/SL hit.
+func shouldMACDPeakExit(cfg *config.Config, macd, signal []float64, isBull bool, pnlPct float64) bool {
+	if cfg == nil || !cfg.ScalpMode.MACDPeakExit || pnlPct <= 0 || len(macd) < 3 || len(signal) < 3 {
+		return false
+	}
+	h0 := macd[len(macd)-1] - signal[len(signal)-1]
+	h1 := macd[len(macd)-2] - signal[len(signal)-2]
+	h2 := macd[len(macd)-3] - signal[len(signal)-3]
+	if isBull {
+		// Was rising (h2<h1), now falling (h1>h0) → peak
+		return h2 < h1 && h0 < h1
+	}
+	// Was falling (h2>h1), now rising (h1<h0) → trough
+	return h2 > h1 && h0 > h1
+}

--- a/strategy/scalp_helpers.go
+++ b/strategy/scalp_helpers.go
@@ -139,6 +139,19 @@ func evaluateScalp(in scalpEvalInput) scalpEvalResult {
 		dirSym = "<"
 	}
 	macdLabel := fmt.Sprintf("MACD histogram %s prev for %d bar(s) (hist=%.6f, prev=%.6f)", dirSym, consec, hist, prevHist)
+
+	// Optional: require meaningful prior MACD/signal separation in the lookback
+	// (bull: hist must have reached <= -min-separation; bear: >= +min-separation).
+	// Catches "the gap was real, now it's closing in" — filters out flat noise.
+	if cfg.Indicators.Macd.MinSeparation > 0 {
+		lookback := cfg.Indicators.Macd.MinSepLookback
+		if lookback <= 0 {
+			lookback = 20
+		}
+		hadSep, peakSep := macdHadMinSeparation(in.MACDLine, in.SignalLine, lookback, cfg.Indicators.Macd.MinSeparation, in.IsBull)
+		macdMet = macdMet && hadSep
+		macdLabel = fmt.Sprintf("%s & |peak-sep| %.6f ≥ %.6f over %d bars", macdLabel, peakSep, cfg.Indicators.Macd.MinSeparation, lookback)
+	}
 	addCondition(&res, cfg, "macd", macdLabel, macdMet)
 
 	// ---- 3. Tendency / fast trend gate ----
@@ -259,6 +272,53 @@ func histDirectionHolds(macd, signal []float64, n int, isBull bool) bool {
 		}
 	}
 	return true
+}
+
+// macdHadMinSeparation returns (true, peakSignedSep) when, within the last
+// `lookback` bars of the histogram (macd-signal), there was at least one bar
+// whose histogram reached the configured prior-divergence threshold in the
+// direction opposite to the current trade — i.e. for a BULL trade the
+// histogram must have been ≤ -minSep at some point (MACD meaningfully below
+// signal) before now closing back in; for BEAR the histogram must have been
+// ≥ +minSep. peakSignedSep is the most extreme value found in that window
+// (negative for bull-side check, positive for bear-side) — useful for logging.
+func macdHadMinSeparation(macd, signal []float64, lookback int, minSep float64, isBull bool) (bool, float64) {
+	if lookback < 1 || minSep <= 0 || len(macd) < 2 || len(signal) < 2 {
+		return false, 0
+	}
+	start := len(macd) - lookback
+	if start < 0 {
+		start = 0
+	}
+	if start > len(signal)-1 {
+		return false, 0
+	}
+	if start > len(macd)-1 {
+		return false, 0
+	}
+	var peak float64
+	first := true
+	for i := start; i < len(macd) && i < len(signal); i++ {
+		h := macd[i] - signal[i]
+		if first {
+			peak = h
+			first = false
+			continue
+		}
+		if isBull {
+			if h < peak { // most negative
+				peak = h
+			}
+		} else {
+			if h > peak { // most positive
+				peak = h
+			}
+		}
+	}
+	if isBull {
+		return peak <= -minSep, peak
+	}
+	return peak >= minSep, peak
 }
 
 // effectiveTPAndSL computes take-profit / stop-loss percentages, applying

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -297,20 +297,41 @@ func (d *Dashboard) showConfig(mainLayout *tview.Flex) {
 		b.WriteString(" [gray]No configuration loaded[-]\n")
 	} else {
 		c := d.cfg
+		b.WriteString("[yellow::b]General[-]\n")
+		b.WriteString(fmt.Sprintf("  Base URL: [white]%s[-]\n", c.BaseURL))
+		b.WriteString(fmt.Sprintf("  Data Dir: [white]%s[-]\n", c.DataDir))
+		b.WriteString(fmt.Sprintf("  Refresh Interval: [white]%ds[-]\n\n", c.RefreshInterval))
+
 		b.WriteString("[yellow::b]Historical Prices[-]\n")
-		b.WriteString(fmt.Sprintf("  Period: [white]%d[-]  Interval: [white]%s[-]\n", c.HistoricalPrices.Period, c.HistoricalPrices.Interval))
-		b.WriteString(fmt.Sprintf("  Refresh: [white]%ds[-]\n\n", c.RefreshInterval))
+		b.WriteString(fmt.Sprintf("  Period: [white]%d[-]  Interval: [white]%s[-]\n\n", c.HistoricalPrices.Period, c.HistoricalPrices.Interval))
+
+		b.WriteString("[yellow::b]Order Management[-]\n")
+		b.WriteString(fmt.Sprintf("  Buy Timeout: [white]%dm[-]  Sell Timeout: [white]%dm[-]\n",
+			c.OrderManagement.BuyTimeoutMinutes, c.OrderManagement.SellTimeoutMinutes))
+		b.WriteString(fmt.Sprintf("  Partial-Fill Action: [white]%s[-]  Poll Interval: [white]%ds[-]\n\n",
+			c.OrderManagement.PartialFillAction, c.OrderManagement.PollIntervalSecs))
+
+		b.WriteString("[yellow::b]Fees[-]\n")
+		b.WriteString(fmt.Sprintf("  Enabled: [white]%v[-]  Default Taker: [white]%.3f%%[-]\n",
+			c.Fees.Enabled, c.Fees.DefaultTakerPct))
+		b.WriteString(fmt.Sprintf("  Buffer: [white]%.3f%%[-]  Buy-Back Buffer: [white]%.3f%%[-]\n\n",
+			c.Fees.BufferPct, c.Fees.BuyBackBufferPct))
 
 		b.WriteString("[yellow::b]Tendency[-]\n")
-		b.WriteString(fmt.Sprintf("  Interval: [white]%s[-]\n", c.Tendency.Interval))
-		b.WriteString(fmt.Sprintf("  HTF Enabled: [white]%v[-]  HTF Interval: [white]%s[-]\n\n", c.Tendency.HTFEnabled, c.Tendency.HTFInterval))
+		b.WriteString(fmt.Sprintf("  Interval: [white]%s[-]  Period: [white]%d[-]\n", c.Tendency.Interval, c.Tendency.Period))
+		b.WriteString(fmt.Sprintf("  Fast Len: [white]%d[-]  Slow Len: [white]%d[-]  Confirm Bars: [white]%d[-]\n",
+			c.Tendency.FastLength, c.Tendency.SlowLength, c.Tendency.ConfirmBars))
+		b.WriteString(fmt.Sprintf("  HTF Enabled: [white]%v[-]  HTF Interval: [white]%s[-]  HTF Period: [white]%d[-]\n",
+			c.Tendency.HTFEnabled, c.Tendency.HTFInterval, c.Tendency.HTFPeriod))
+		b.WriteString(fmt.Sprintf("  HTF Fast: [white]%d[-]  HTF Slow: [white]%d[-]  HTF Confirm: [white]%d[-]\n\n",
+			c.Tendency.HTFFastLength, c.Tendency.HTFSlowLength, c.Tendency.HTFConfirmBars))
 
 		b.WriteString("[yellow::b]Indicators[-]\n")
-		b.WriteString(fmt.Sprintf("  RSI: interval=[white]%s[-] len=[white]%d[-] upper=[white]%d[-] mid=[white]%d[-] lower=[white]%d[-]\n",
-			c.Indicators.Rsi.Interval, c.Indicators.Rsi.Length, c.Indicators.Rsi.UpperLimit, c.Indicators.Rsi.MiddleLimit, c.Indicators.Rsi.LowerLimit))
+		b.WriteString(fmt.Sprintf("  RSI: interval=[white]%s[-] len=[white]%d[-] upper=[white]%d[-] mid=[white]%d[-] lower=[white]%d[-] smooth=[white]%d[-]\n",
+			c.Indicators.Rsi.Interval, c.Indicators.Rsi.Length, c.Indicators.Rsi.UpperLimit, c.Indicators.Rsi.MiddleLimit, c.Indicators.Rsi.LowerLimit, c.Indicators.Rsi.SmoothLength))
 		b.WriteString(fmt.Sprintf("  DEMA: len=[white]%d[-]\n", c.Indicators.Dema.Length))
-		b.WriteString(fmt.Sprintf("  MACD: fast=[white]%d[-] slow=[white]%d[-] signal=[white]%d[-]\n",
-			c.Indicators.Macd.FastLength, c.Indicators.Macd.SlowLength, c.Indicators.Macd.SignalLength))
+		b.WriteString(fmt.Sprintf("  MACD: fast=[white]%d[-] slow=[white]%d[-] signal=[white]%d[-] consec-bars=[white]%d[-]\n",
+			c.Indicators.Macd.FastLength, c.Indicators.Macd.SlowLength, c.Indicators.Macd.SignalLength, c.Indicators.Macd.ConsecutiveBars))
 		b.WriteString(fmt.Sprintf("  Bollinger: len=[white]%d[-] mult=[white]%.1f[-]\n",
 			c.Indicators.BollingerBands.Length, c.Indicators.BollingerBands.Multiplier))
 		b.WriteString(fmt.Sprintf("  ATR: period=[white]%d[-]\n", c.Indicators.Atr.Period))
@@ -325,10 +346,25 @@ func (d *Dashboard) showConfig(mainLayout *tview.Flex) {
 		b.WriteString(fmt.Sprintf("  Enabled: [white]%v[-]  Min Score: [white]%d[-]\n", c.ScalpMode.Enabled, c.ScalpMode.MinScore))
 		b.WriteString(fmt.Sprintf("  Post-Buy Delay: [white]%ds[-]  Inter-Op Delay: [white]%ds[-]\n",
 			c.ScalpMode.PostBuyDelay, c.ScalpMode.InterOpDelay))
-		b.WriteString(fmt.Sprintf("  RSI Exit: [white]%v[-]  SL Cooldown: [white]%v[-]\n",
-			c.ScalpMode.RequireRSIExit, c.ScalpMode.SLCooldown))
-		b.WriteString(fmt.Sprintf("  ATR Stop-Loss: [white]%v[-]  ATR Mult: [white]%.1f[-]\n\n",
+		b.WriteString(fmt.Sprintf("  RSI Exit: [white]%v[-]  SL Cooldown: [white]%v[-]  Max Consec SL: [white]%d[-]  Cooldown Base: [white]%ds[-]\n",
+			c.ScalpMode.RequireRSIExit, c.ScalpMode.SLCooldown, c.ScalpMode.MaxConsecutiveSL, c.ScalpMode.CooldownBaseSecs))
+		b.WriteString(fmt.Sprintf("  ATR Stop-Loss: [white]%v[-]  ATR Mult: [white]%.2f[-]\n",
 			c.ScalpMode.ATRStopLoss, c.ScalpMode.ATRMultiplier))
+		b.WriteString("  [gray]-- v0.14.0 --[-]\n")
+		b.WriteString(fmt.Sprintf("  Weighted Scoring: [white]%v[-]  Fast Trend Gate: [white]%v[-]  MACD-Peak Exit: [white]%v[-]\n",
+			c.ScalpMode.WeightedScoring, c.ScalpMode.FastTrendGate, c.ScalpMode.MACDPeakExit))
+		b.WriteString(fmt.Sprintf("  BB Squeeze: enabled=[white]%v[-] ratio=[white]%.2f[-] window=[white]%d[-]\n",
+			c.ScalpMode.BBSqueezeEnabled, c.ScalpMode.BBSqueezeRatio, c.ScalpMode.BBSqueezeWindow))
+		b.WriteString(fmt.Sprintf("  Vol Strong Mult: [white]%.2f[-]\n", c.ScalpMode.VolumeStrongMultiplier))
+		b.WriteString(fmt.Sprintf("  Divergence: enabled=[white]%v[-] lookback=[white]%d[-] swing-pad=[white]%d[-]\n",
+			c.ScalpMode.DivergenceEnabled, c.ScalpMode.DivergenceLookback, c.ScalpMode.DivergenceSwingPad))
+		b.WriteString(fmt.Sprintf("  TP ATR Mult: [white]%.2f[-]  SL ATR Mult: [white]%.2f[-]\n",
+			c.ScalpMode.TPATRMultiplier, c.ScalpMode.SLATRMultiplier))
+		b.WriteString(fmt.Sprintf("  Time-Stop Bars: [white]%d[-]  Break-Even ATR Mult: [white]%.2f[-]\n",
+			c.ScalpMode.TimeStopBars, c.ScalpMode.BreakevenATRMult))
+		b.WriteString(fmt.Sprintf("  Regime ATR%%: min=[white]%.3f[-] max=[white]%.3f[-]\n",
+			c.ScalpMode.MinATRPct, c.ScalpMode.MaxATRPct))
+		b.WriteString(fmt.Sprintf("  Recent Extreme Bars: [white]%d[-]\n\n", c.ScalpMode.RecentExtremeBars))
 
 		b.WriteString("[yellow::b]AI Agents[-]\n")
 		b.WriteString(fmt.Sprintf("  Enabled: [white]%v[-]  Min Confidence: [white]%.0f%%[-]\n",
@@ -340,20 +376,46 @@ func (d *Dashboard) showConfig(mainLayout *tview.Flex) {
 		}
 		b.WriteString("\n")
 
-		b.WriteString("[dimgray]Press [white::b]c[-][dimgray] or [white::b]Esc[-][dimgray] to close[-]")
+		b.WriteString("[yellow::b]Top Gainers[-]\n")
+		b.WriteString(fmt.Sprintf("  Quote: [white]%s[-]  Limit: [white]%d[-]  Poll: [white]%ds[-]  Min Vol: [white]%.0f[-]\n",
+			c.TopGainers.QuoteAsset, c.TopGainers.Limit, c.TopGainers.PollInterval, c.TopGainers.MinVolume))
+		if len(c.TopGainers.ExcludeSymbols) > 0 {
+			b.WriteString(fmt.Sprintf("  Exclude: [white]%s[-]\n", strings.Join(c.TopGainers.ExcludeSymbols, ", ")))
+		}
+		b.WriteString("\n")
+
+		b.WriteString("[yellow::b]Rotation[-]\n")
+		b.WriteString(fmt.Sprintf("  Bridge: [white]%s[-]  Current: [white]%s[-]\n",
+			c.Rotation.BridgeAsset, c.Rotation.CurrentAsset))
+		if len(c.Rotation.SupportedAssets) > 0 {
+			b.WriteString(fmt.Sprintf("  Supported: [white]%s[-]\n", strings.Join(c.Rotation.SupportedAssets, ", ")))
+		}
+		b.WriteString(fmt.Sprintf("  Scout Mult: [white]%.2f[-]  Scout Margin: [white]%.2f%%[-]  Use Margin: [white]%v[-]\n",
+			c.Rotation.ScoutMultiplier, c.Rotation.ScoutMarginPct, c.Rotation.UseMargin))
+		b.WriteString(fmt.Sprintf("  Scout Sleep: [white]%ds[-]  Dry Run: [white]%v[-]  Max Jumps: [white]%d[-]  Min Notional Buf: [white]%.3f[-]\n\n",
+			c.Rotation.ScoutSleepSeconds, c.Rotation.DryRun, c.Rotation.MaxJumps, c.Rotation.MinNotionalBuffer))
+
+		b.WriteString("[yellow::b]Backtest[-]\n")
+		b.WriteString(fmt.Sprintf("  Initial Balance: [white]%.2f[-]  Fee: [white]%.3f%%[-]\n\n",
+			c.Backtest.InitialBalance, c.Backtest.FeePct))
+
+		b.WriteString("[yellow::b]API[-]\n")
+		b.WriteString(fmt.Sprintf("  Address: [white]%s[-]\n\n", c.API.Address))
+
+		b.WriteString("[dimgray]Press [white::b]c[-][dimgray] or [white::b]Esc[-][dimgray] to close · scroll with arrows/PgUp/PgDn[-]")
 	}
 
 	cfgView.SetText(b.String())
 
-	// Center the config modal
+	// Center the config modal (taller to fit all sections; remains scrollable for small terminals)
 	modal := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(nil, 0, 1, false).
 		AddItem(
 			tview.NewFlex().SetDirection(tview.FlexColumn).
 				AddItem(nil, 0, 1, false).
-				AddItem(cfgView, 65, 0, true).
+				AddItem(cfgView, 95, 0, true).
 				AddItem(nil, 0, 1, false),
-			28, 0, true).
+			50, 0, true).
 		AddItem(nil, 0, 1, false)
 
 	// Overlay modal on top of main layout

--- a/tui/dashboard.go
+++ b/tui/dashboard.go
@@ -332,6 +332,8 @@ func (d *Dashboard) showConfig(mainLayout *tview.Flex) {
 		b.WriteString(fmt.Sprintf("  DEMA: len=[white]%d[-]\n", c.Indicators.Dema.Length))
 		b.WriteString(fmt.Sprintf("  MACD: fast=[white]%d[-] slow=[white]%d[-] signal=[white]%d[-] consec-bars=[white]%d[-]\n",
 			c.Indicators.Macd.FastLength, c.Indicators.Macd.SlowLength, c.Indicators.Macd.SignalLength, c.Indicators.Macd.ConsecutiveBars))
+		b.WriteString(fmt.Sprintf("    min-separation=[white]%.4f[-]  min-sep-lookback=[white]%d[-]\n",
+			c.Indicators.Macd.MinSeparation, c.Indicators.Macd.MinSepLookback))
 		b.WriteString(fmt.Sprintf("  Bollinger: len=[white]%d[-] mult=[white]%.1f[-]\n",
 			c.Indicators.BollingerBands.Length, c.Indicators.BollingerBands.Multiplier))
 		b.WriteString(fmt.Sprintf("  ATR: period=[white]%d[-]\n", c.Indicators.Atr.Period))


### PR DESCRIPTION
# feat(strategy): comprehensive scalp indicator overhaul (v0.14.0)

Branch: `feat/macd-anticipatory-scalp`

## Summary

Comprehensive rework of the scalp trading pipeline that lands **16 indicator/entry/exit
improvements** behind opt-in config knobs (defaults stay close to v0.13.x behavior except
for two intentional scalp-default changes documented below). All changes are concentrated
in a single helper (`strategy/scalp_helpers.go`) so the four scalp call sites in
`registry.go`, `bull.go`, `bear.go`, and `dynamic.go` collapse into a small uniform call.

## What's new (16 items)

### Indicator layer (`indicator/extras.go`)
1. `CalculateSmoothedRSI(prices, period, smoothLength)` — optional SMA-smoothed RSI to
   reduce flicker (`indicators.rsi.smooth-length`, default 0 = identical to v0.13.x).
2. `CalculateStochRSI(prices, rsiPeriod, stochPeriod)` — Stochastic RSI helper (available
   for future strategies / AI snapshots).
3. `BollingerWidthRatio(bb, avgWindow)` — squeeze detection.
4. `findSwingExtrema` + `BullishDivergence` / `BearishDivergence` — proper swing-based
   divergence detection.
5. `RecentExtremeLookback(closes, lookback)` — recent-extreme guard input.

### Config layer (`config/file.go`)
6. `indicators.rsi.smooth-length` and `indicators.macd.consecutive-bars`.
7. 16 new `scalp-mode.*` knobs (all opt-in): `weighted-scoring`, `bb-squeeze-enabled`,
   `bb-squeeze-ratio`, `bb-squeeze-window`, `volume-strong-multiplier`,
   `divergence-enabled`, `divergence-lookback`, `divergence-swing-pad`,
   `fast-trend-gate`, `tp-atr-multiplier`, `sl-atr-multiplier`, `time-stop-bars`,
   `breakeven-atr-mult`, `min-atr-pct`, `max-atr-pct`, `macd-peak-exit`,
   `recent-extreme-bars`.

### Scalp scoring (`strategy/scalp_helpers.go`)
8. **Weighted scoring** — MACD/RSI/BB count ×2, divergence ×3 when enabled.
9. **Pullback-in-trend RSI** — replaces extreme-RSI scalp signal: RSI below mid-line
   and rising for 2 consecutive bars (bull mirror for bear).
10. **Bollinger price-touch** — replaces DEMA-distance: scoring fires when close
    touches/crosses the band (bull: ≤ lower; bear: ≥ upper).
11. **BB squeeze bonus** — opt-in: awards a signal when current BB width ≤ ratio × avg
    width over a window (energy build-up).
12. **Volume strong-multiplier bonus** — opt-in: extra signal when `volume > mult × MA`.
13. **RSI divergence bonus** — opt-in, weighted ×3 when enabled.
14. **Fast-trend-gate** — opt-in: accept trend signal if *either* tendency aligns *or*
    MACD line is on the correct side of zero.
15. **MACD consecutive-bars** — `histDirectionHolds`: require N successive bars of
    histogram direction before awarding the MACD signal.
16. **Regime filter + recent-extreme block** — pre-scoring veto gates using
    `min-atr-pct`/`max-atr-pct` and `recent-extreme-bars`.

### Exit layer (4 monitoring loops in `bull.go`, `bear.go`, `dynamic.go ×2`)
17. **`effectiveTPAndSL` helper** — applies `tp-atr-multiplier` / `sl-atr-multiplier`
    overrides plus the existing `atr-stop-loss` floor in a single call.
18. **Time-stop** — exits flat positions (P&L ≥ 0 but TP not reached) after
    `time-stop-bars` bars.
19. **Break-even pin** — once peak P&L ≥ `breakeven-atr-mult × ATR%`, pins SL to entry
    price.
20. **MACD-peak exit** — `shouldMACDPeakExit`: lock gains when MACD histogram rolls
    over for 3 bars while in profit.
21. **Smoothed RSI threaded everywhere** — all entry- and exit-phase RSI calls now
    flow through `CalculateSmoothedRSI`.

(16 numbered scalp improvements; 21 lines if you count the supporting helpers — but
the user request was the 16 enumerated items.)

## Default-behavior changes (intentional)

1. **Scalp RSI signal** — pullback-in-trend replaces "RSI < lower-limit". Catches turning
   points earlier and meshes with `smooth-length`.
2. **Scalp BB signal** — price-touch replaces DEMA-distance-to-band. Catches actual
   reversion entries instead of probabilistic proximity.

Classic-mode behavior is **unchanged**. All other scalp knobs default to 0/false and reproduce
v0.13.4 behavior at those defaults.

## Files changed

- `main.go` — Version `v0.13.4` → `v0.14.0`.
- `indicator/extras.go` (new).
- `config/file.go` — new struct fields (all yaml-tagged).
- `strategy/scalp_helpers.go` (new) — `evaluateScalp`, `effectiveTPAndSL`,
  `shouldMACDPeakExit`, `histDirectionHolds`, etc.
- `strategy/registry.go` — `scalpBullStrategy.Decide()` uses `evaluateScalp`.
- `strategy/bull.go` — scalp entry uses `evaluateScalp`; monitoring loop wires
  `effectiveTPAndSL`, time-stop, break-even, MACD-peak.
- `strategy/bear.go` — mirror of bull.go.
- `strategy/dynamic.go` — same two changes applied to both bull and bear branches.
- `README.md` — features list, version, scalp-mode config table, trade-logic sections.

## Validation

- `go build ./...` — clean.
- `go test ./...` — `ai`, `config`, `exchange`, `indicator` all PASS.

## Version bump

`v0.13.4` → **`v0.14.0`** (MINOR — new opt-in features, two intentional scalp default
changes documented above).