### PR TITLE
fix(strategy): unify live/backtest entry decision path (v0.14.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Advanced Indicators** — RSI (+ optional SMA smoothing), MACD, DEMA, Bollinger Bands (+ width-ratio for squeeze), ADX, ATR, Stochastic RSI, swing-extrema divergence, and volume confirmation
 - **Top Gainers Monitor** — Real-time TUI dashboard of the top 24h movers on Binance
 - **Rotation Scout Mode** — Scans a configured asset basket and rotates through a bridge asset when relative ratios become fee-adjusted opportunities
-- **Backtesting** — Runs registered strategy simulations over recent Binance candles before live trading
+- **Backtesting** — Runs registered strategy simulations over recent Binance candles before live trading, using the same shared entry-decision path as the live loops (smoothed RSI, ADX and volume gates included)
 - **Managed Orders** — Optional buy/sell timeouts with partial-fill handling; unfilled entries return to scanning instead of advancing to exit monitoring
 - **Pre-Order Balance Checks** — Reads Binance spot account balances before placing orders and blocks buys/sells that exceed available free funds
 - **Persistent History API** — Stores trade/scout history in JSONL and serves it through a small local HTTP API
@@ -180,6 +180,8 @@ binance-bot -f binance-config.yml backtest -t "BTC/USDT" --strategy classic-bull
 
 Runs a registered strategy over recent Binance candles using the configured indicators, starting balance, and fee assumptions. Available strategies are `classic-bull` and `scalp-bull`.
 
+As of v0.14.3, backtest strategies evaluate entries through the exact same shared decision path as live trading: smoothed RSI (`indicators.rsi.smooth-length`), the ADX gate, and volume confirmation are honored in backtests exactly as configured, instead of being skipped. Backtest results are therefore representative of live entry behavior for the same config.
+
 #### History API
 
 ```bash
@@ -234,7 +236,7 @@ These arguments apply to the `auto-trade`, `bull-trade`, and `bear-trade` comman
      binance-bot [global options] command <command args>
 
   VERSION:
-     v0.14.2
+     v0.14.3
 
   AUTHOR:
      Walter Ferreira <wferreirauy@gmail.com>

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:     "binance-bot",
-		Version:  "v0.14.2",
+		Version:  "v0.14.3",
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
 			{

--- a/strategy/bear.go
+++ b/strategy/bear.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"reflect"
 	"regexp"
@@ -158,68 +157,23 @@ func bearTradeLoop(
 				continue
 			}
 
-			// indicators
-			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
-			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
-			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
-			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+			// indicators — shared entry-signal computation (same path as backtest)
+			sig, err := computeEntrySignals(ohlcv, cfg, tendency)
 			if err != nil {
-				dash.LogError(fmt.Sprintf("BollingerBands: %v", err))
+				dash.LogError(fmt.Sprintf("Entry signals: %v", err))
+				time.Sleep(refreshInterval)
+				continue
 			}
-			lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
-			upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-			distanceToUpper := math.Abs(currentDema - upperBand)
-			distanceToLower := math.Abs(currentDema - lowerBand)
+			rsi := sig.RSI
+			macdLine, signalLine := sig.MACDLine, sig.SignalLine
 
-			// MACD cross
-			macdCross := "BULLISH"
-			if macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] && macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1] {
-				macdCross = "BEARISH"
-			}
-
-			// ADX
-			var adxVal float64
-			var adxStrong bool
-			if cfg.Indicators.Adx.Period > 0 {
-				adx := indicator.CalculateADX(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Adx.Period)
-				if len(adx) > 0 {
-					adxVal = adx[len(adx)-1]
-				}
-				adxStrong = len(adx) == 0 || adxVal > float64(cfg.Indicators.Adx.Threshold)
-			} else {
-				adxStrong = true
-			}
-
-			// Volume
-			var currentVolume, avgVolume float64
-			var volumeConfirmed bool
-			if cfg.Indicators.Volume.MaPeriod > 0 {
-				volumeMA := indicator.CalculateSMA(ohlcv.Volumes, cfg.Indicators.Volume.MaPeriod)
-				currentVolume = ohlcv.Volumes[len(ohlcv.Volumes)-1]
-				if len(volumeMA) > 0 {
-					avgVolume = volumeMA[len(volumeMA)-1]
-				}
-				volumeConfirmed = len(volumeMA) == 0 || currentVolume > avgVolume
-			} else {
-				volumeConfirmed = true
-			}
-
-			// Update indicators panel
-			var atrVal float64
-			if cfg.Indicators.Atr.Period > 0 {
-				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-				if len(atrSeries) > 0 {
-					atrVal = atrSeries[len(atrSeries)-1]
-				}
-			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
-				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
-				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
-				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
-				Volume: currentVolume, AvgVolume: avgVolume,
-				ATR: atrVal, Price: price,
+				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCrossLabel(sig, false),
+				DEMA: sig.DEMA, UpperBand: sig.UpperBand, LowerBand: sig.LowerBand,
+				Tendency: tendency, ADX: sig.ADXVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
+				Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
+				ATR: sig.ATRVal, Price: price,
 			})
 
 			// AI analysis
@@ -229,8 +183,8 @@ func bearTradeLoop(
 					Symbol: symbol, Price: price, PrevPrice: prevPrice,
 					RSI: rsi[len(rsi)-1], MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1],
 					PrevMACDLine: macdLine[len(macdLine)-2], PrevSignalLine: signalLine[len(signalLine)-2],
-					UpperBand: upperBand, LowerBand: lowerBand, DEMA: currentDema, Tendency: tendency,
-					ADX: adxVal, Volume: currentVolume, AvgVolume: avgVolume,
+					UpperBand: sig.UpperBand, LowerBand: sig.LowerBand, DEMA: sig.DEMA, Tendency: tendency,
+					ADX: sig.ADXVal, Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 				consensus, err := aiOrch.Analyze(ctx, snapshot, "BEAR")
@@ -260,15 +214,7 @@ func bearTradeLoop(
 			// when to sell (bear entry) — scalp mode uses scoring; classic mode requires all conditions
 			var shouldSell bool
 			if cfg.ScalpMode.Enabled {
-				eval := evaluateScalp(scalpEvalInput{
-					IsBull: false, Cfg: cfg,
-					Closes: ohlcv.Closes, RSI: rsi,
-					MACDLine: macdLine, SignalLine: signalLine,
-					BB: bb, Tendency: tendency,
-					ADXStrong: adxStrong, ADXVal: adxVal,
-					CurrentVolume: currentVolume, AvgVolume: avgVolume,
-					ATRVal: atrVal, Price: price,
-				})
+				eval := evaluateScalp(scalpInputFromSignals(sig, cfg, false, ohlcv.Closes))
 				if eval.RegimeBlocked {
 					dash.LogInfo(fmt.Sprintf("[yellow]Regime gate[-] %s — skipping BEAR entry", eval.RegimeReason))
 					time.Sleep(refreshInterval)
@@ -287,24 +233,9 @@ func bearTradeLoop(
 					}
 				}
 			} else {
-				rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
-				macdCrossOk := macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] &&
-					macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
-				tendOk := tendency == "down"
-				bbOk := distanceToUpper < distanceToLower
-
-				shouldSell = rsiOk && macdCrossOk && tendOk && bbOk &&
-					adxStrong && volumeConfirmed && aiApproved
-
+				met, conditions := evaluateClassicEntry(sig, cfg, false)
+				shouldSell = met && aiApproved
 				if shouldSell {
-					conditions := []entryCondition{
-						{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
-						{Name: fmt.Sprintf("MACD bearish crossover (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
-						{Name: fmt.Sprintf("Tendency %s = down", tendency), Met: tendOk},
-						{Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower), Met: bbOk},
-						{Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold), Met: adxStrong},
-						{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume), Met: volumeConfirmed},
-					}
 					logEntryConditions(dash, "BEAR", conditions, 6, 6, 6, false)
 				}
 			}

--- a/strategy/bull.go
+++ b/strategy/bull.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"reflect"
 	"regexp"
@@ -157,68 +156,23 @@ func bullTradeLoop(
 				continue
 			}
 
-			// indicators
-			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
-			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
-			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
-			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+			// indicators — shared entry-signal computation (same path as backtest)
+			sig, err := computeEntrySignals(ohlcv, cfg, tendency)
 			if err != nil {
-				dash.LogError(fmt.Sprintf("BollingerBands: %v", err))
+				dash.LogError(fmt.Sprintf("Entry signals: %v", err))
+				time.Sleep(refreshInterval)
+				continue
 			}
-			lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
-			upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-			distanceToUpper := math.Abs(currentDema - upperBand)
-			distanceToLower := math.Abs(currentDema - lowerBand)
+			rsi := sig.RSI
+			macdLine, signalLine := sig.MACDLine, sig.SignalLine
 
-			// MACD cross description
-			macdCross := "BEARISH"
-			if macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] && macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] {
-				macdCross = "BULLISH"
-			}
-
-			// ADX
-			var adxVal float64
-			var adxStrong bool
-			if cfg.Indicators.Adx.Period > 0 {
-				adx := indicator.CalculateADX(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Adx.Period)
-				if len(adx) > 0 {
-					adxVal = adx[len(adx)-1]
-				}
-				adxStrong = len(adx) == 0 || adxVal > float64(cfg.Indicators.Adx.Threshold)
-			} else {
-				adxStrong = true
-			}
-
-			// Volume
-			var currentVolume, avgVolume float64
-			var volumeConfirmed bool
-			if cfg.Indicators.Volume.MaPeriod > 0 {
-				volumeMA := indicator.CalculateSMA(ohlcv.Volumes, cfg.Indicators.Volume.MaPeriod)
-				currentVolume = ohlcv.Volumes[len(ohlcv.Volumes)-1]
-				if len(volumeMA) > 0 {
-					avgVolume = volumeMA[len(volumeMA)-1]
-				}
-				volumeConfirmed = len(volumeMA) == 0 || currentVolume > avgVolume
-			} else {
-				volumeConfirmed = true
-			}
-
-			// Update indicators panel
-			var atrVal float64
-			if cfg.Indicators.Atr.Period > 0 {
-				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-				if len(atrSeries) > 0 {
-					atrVal = atrSeries[len(atrSeries)-1]
-				}
-			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
-				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
-				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
-				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
-				Volume: currentVolume, AvgVolume: avgVolume,
-				ATR: atrVal, Price: price,
+				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCrossLabel(sig, true),
+				DEMA: sig.DEMA, UpperBand: sig.UpperBand, LowerBand: sig.LowerBand,
+				Tendency: tendency, ADX: sig.ADXVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
+				Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
+				ATR: sig.ATRVal, Price: price,
 			})
 
 			// AI analysis
@@ -228,8 +182,8 @@ func bullTradeLoop(
 					Symbol: symbol, Price: price, PrevPrice: prevPrice,
 					RSI: rsi[len(rsi)-1], MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1],
 					PrevMACDLine: macdLine[len(macdLine)-2], PrevSignalLine: signalLine[len(signalLine)-2],
-					UpperBand: upperBand, LowerBand: lowerBand, DEMA: currentDema, Tendency: tendency,
-					ADX: adxVal, Volume: currentVolume, AvgVolume: avgVolume,
+					UpperBand: sig.UpperBand, LowerBand: sig.LowerBand, DEMA: sig.DEMA, Tendency: tendency,
+					ADX: sig.ADXVal, Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 				consensus, err := aiOrch.Analyze(ctx, snapshot, "BULL")
@@ -259,15 +213,7 @@ func bullTradeLoop(
 			// when to buy — scalp mode uses scoring; classic mode requires all conditions
 			var shouldBuy bool
 			if cfg.ScalpMode.Enabled {
-				eval := evaluateScalp(scalpEvalInput{
-					IsBull: true, Cfg: cfg,
-					Closes: ohlcv.Closes, RSI: rsi,
-					MACDLine: macdLine, SignalLine: signalLine,
-					BB: bb, Tendency: tendency,
-					ADXStrong: adxStrong, ADXVal: adxVal,
-					CurrentVolume: currentVolume, AvgVolume: avgVolume,
-					ATRVal: atrVal, Price: price,
-				})
+				eval := evaluateScalp(scalpInputFromSignals(sig, cfg, true, ohlcv.Closes))
 				if eval.RegimeBlocked {
 					dash.LogInfo(fmt.Sprintf("[yellow]Regime gate[-] %s — skipping BULL entry", eval.RegimeReason))
 					time.Sleep(refreshInterval)
@@ -286,24 +232,9 @@ func bullTradeLoop(
 					}
 				}
 			} else {
-				rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
-				macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
-					macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
-				tendOk := tendency == "up"
-				bbOk := distanceToLower < distanceToUpper
-
-				shouldBuy = rsiOk && macdCrossOk && tendOk && bbOk &&
-					adxStrong && volumeConfirmed && aiApproved
-
+				met, conditions := evaluateClassicEntry(sig, cfg, true)
+				shouldBuy = met && aiApproved
 				if shouldBuy {
-					conditions := []entryCondition{
-						{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
-						{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
-						{Name: fmt.Sprintf("Tendency %s = up", tendency), Met: tendOk},
-						{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},
-						{Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold), Met: adxStrong},
-						{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume), Met: volumeConfirmed},
-					}
 					logEntryConditions(dash, "BULL", conditions, 6, 6, 6, false)
 				}
 			}

--- a/strategy/dynamic.go
+++ b/strategy/dynamic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"reflect"
 	"regexp"
@@ -374,76 +373,23 @@ operationLoop:
 				}
 			}
 
-			// indicators
-			dema := indicator.CalculateDEMA(ohlcv.Closes, cfg.Indicators.Dema.Length)
-			currentDema := dema[len(dema)-1]
-			rsi := indicator.CalculateSmoothedRSI(ohlcv.Closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
-			macdLine, signalLine := indicator.CalculateMACD(ohlcv.Closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
-			bb, err := indicator.CalculateBollingerBands(ohlcv.Closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+			// indicators — shared entry-signal computation (same path as backtest)
+			sig, err := computeEntrySignals(ohlcv, cfg, tendency)
 			if err != nil {
-				dash.LogError(fmt.Sprintf("BollingerBands: %v", err))
+				dash.LogError(fmt.Sprintf("Entry signals: %v", err))
+				time.Sleep(refreshInterval)
+				continue
 			}
-			lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
-			upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-			distanceToUpper := math.Abs(currentDema - upperBand)
-			distanceToLower := math.Abs(currentDema - lowerBand)
+			rsi := sig.RSI
+			macdLine, signalLine := sig.MACDLine, sig.SignalLine
 
-			// MACD cross description
-			var macdCross string
-			if isBull {
-				macdCross = "BEARISH"
-				if macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] && macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1] {
-					macdCross = "BULLISH"
-				}
-			} else {
-				macdCross = "BULLISH"
-				if macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] && macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1] {
-					macdCross = "BEARISH"
-				}
-			}
-
-			// ADX
-			var adxVal float64
-			var adxStrong bool
-			if cfg.Indicators.Adx.Period > 0 {
-				adx := indicator.CalculateADX(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Adx.Period)
-				if len(adx) > 0 {
-					adxVal = adx[len(adx)-1]
-				}
-				adxStrong = len(adx) == 0 || adxVal > float64(cfg.Indicators.Adx.Threshold)
-			} else {
-				adxStrong = true
-			}
-
-			// Volume
-			var currentVolume, avgVolume float64
-			var volumeConfirmed bool
-			if cfg.Indicators.Volume.MaPeriod > 0 {
-				volumeMA := indicator.CalculateSMA(ohlcv.Volumes, cfg.Indicators.Volume.MaPeriod)
-				currentVolume = ohlcv.Volumes[len(ohlcv.Volumes)-1]
-				if len(volumeMA) > 0 {
-					avgVolume = volumeMA[len(volumeMA)-1]
-				}
-				volumeConfirmed = len(volumeMA) == 0 || currentVolume > avgVolume
-			} else {
-				volumeConfirmed = true
-			}
-
-			// Update indicators panel
-			var atrVal float64
-			if cfg.Indicators.Atr.Period > 0 {
-				atrSeries := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, ohlcv.Closes, cfg.Indicators.Atr.Period)
-				if len(atrSeries) > 0 {
-					atrVal = atrSeries[len(atrSeries)-1]
-				}
-			}
 			dash.UpdateIndicators(&tui.IndicatorData{
 				RSI: rsi[len(rsi)-1], RSIUpperLimit: cfg.Indicators.Rsi.UpperLimit, RSILowerLimit: cfg.Indicators.Rsi.LowerLimit,
-				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCross,
-				DEMA: currentDema, UpperBand: upperBand, LowerBand: lowerBand,
-				Tendency: tendency, ADX: adxVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
-				Volume: currentVolume, AvgVolume: avgVolume,
-				ATR: atrVal, Price: price,
+				MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1], MACDCross: macdCrossLabel(sig, isBull),
+				DEMA: sig.DEMA, UpperBand: sig.UpperBand, LowerBand: sig.LowerBand,
+				Tendency: tendency, ADX: sig.ADXVal, ADXThreshold: cfg.Indicators.Adx.Threshold,
+				Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
+				ATR: sig.ATRVal, Price: price,
 			})
 
 			// AI analysis
@@ -453,8 +399,8 @@ operationLoop:
 					Symbol: symbol, Price: price, PrevPrice: prevPrice,
 					RSI: rsi[len(rsi)-1], MACDLine: macdLine[len(macdLine)-1], SignalLine: signalLine[len(signalLine)-1],
 					PrevMACDLine: macdLine[len(macdLine)-2], PrevSignalLine: signalLine[len(signalLine)-2],
-					UpperBand: upperBand, LowerBand: lowerBand, DEMA: currentDema, Tendency: tendency,
-					ADX: adxVal, Volume: currentVolume, AvgVolume: avgVolume,
+					UpperBand: sig.UpperBand, LowerBand: sig.LowerBand, DEMA: sig.DEMA, Tendency: tendency,
+					ADX: sig.ADXVal, Volume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
 				}
 				aiMode := "BULL"
 				if !isBull {
@@ -498,15 +444,7 @@ operationLoop:
 			// Entry conditions
 			var shouldEnter bool
 			if cfg.ScalpMode.Enabled {
-				eval := evaluateScalp(scalpEvalInput{
-					IsBull: isBull, Cfg: cfg,
-					Closes: ohlcv.Closes, RSI: rsi,
-					MACDLine: macdLine, SignalLine: signalLine,
-					BB: bb, Tendency: tendency,
-					ADXStrong: adxStrong, ADXVal: adxVal,
-					CurrentVolume: currentVolume, AvgVolume: avgVolume,
-					ATRVal: atrVal, Price: price,
-				})
+				eval := evaluateScalp(scalpInputFromSignals(sig, cfg, isBull, ohlcv.Closes))
 				mode := "BULL"
 				if !isBull {
 					mode = "BEAR"
@@ -529,48 +467,14 @@ operationLoop:
 					}
 				}
 			} else {
-				if isBull {
-					rsiOk := rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit)
-					macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
-						macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
-					tendOk := tendency == "up"
-					bbOk := distanceToLower < distanceToUpper
-
-					shouldEnter = rsiOk && macdCrossOk && tendOk && bbOk &&
-						adxStrong && volumeConfirmed && aiApproved
-
-					if shouldEnter {
-						conditions := []entryCondition{
-							{Name: fmt.Sprintf("RSI %.1f < %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
-							{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
-							{Name: fmt.Sprintf("Tendency %s = up", tendency), Met: tendOk},
-							{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},
-							{Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold), Met: adxStrong},
-							{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume), Met: volumeConfirmed},
-						}
-						logEntryConditions(dash, "BULL", conditions, 6, 6, 6, false)
+				met, conditions := evaluateClassicEntry(sig, cfg, isBull)
+				shouldEnter = met && aiApproved
+				if shouldEnter {
+					mode := "BULL"
+					if !isBull {
+						mode = "BEAR"
 					}
-				} else {
-					rsiOk := rsi[len(rsi)-1] > float64(cfg.Indicators.Rsi.UpperLimit)
-					macdCrossOk := macdLine[len(macdLine)-2] >= signalLine[len(signalLine)-2] &&
-						macdLine[len(macdLine)-1] < signalLine[len(signalLine)-1]
-					tendOk := tendency == "down"
-					bbOk := distanceToUpper < distanceToLower
-
-					shouldEnter = rsiOk && macdCrossOk && tendOk && bbOk &&
-						adxStrong && volumeConfirmed && aiApproved
-
-					if shouldEnter {
-						conditions := []entryCondition{
-							{Name: fmt.Sprintf("RSI %.1f > %d", rsi[len(rsi)-1], cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
-							{Name: fmt.Sprintf("MACD bearish crossover (%.6f < %.6f)", macdLine[len(macdLine)-1], signalLine[len(signalLine)-1]), Met: macdCrossOk},
-							{Name: fmt.Sprintf("Tendency %s = down", tendency), Met: tendOk},
-							{Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower), Met: bbOk},
-							{Name: fmt.Sprintf("ADX strong (%.1f > %d)", adxVal, cfg.Indicators.Adx.Threshold), Met: adxStrong},
-							{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", currentVolume, avgVolume), Met: volumeConfirmed},
-						}
-						logEntryConditions(dash, "BEAR", conditions, 6, 6, 6, false)
-					}
+					logEntryConditions(dash, mode, conditions, 6, 6, 6, false)
 				}
 			}
 

--- a/strategy/entry_rules.go
+++ b/strategy/entry_rules.go
@@ -1,0 +1,209 @@
+package strategy
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/exchange"
+	"github.com/wferreirauy/binance-bot/indicator"
+)
+
+// entrySignals is the single, shared indicator snapshot used for entry
+// decisions. Both the live trade loops (bull/bear/dynamic) and the
+// registered backtest strategies derive their decisions from this struct,
+// guaranteeing backtests exercise the same code path as live trading.
+type entrySignals struct {
+	Price     float64
+	PrevPrice float64
+	Tendency  string
+
+	RSI        []float64 // smoothed per config (smooth-length 0/1 = raw RSI)
+	MACDLine   []float64
+	SignalLine []float64
+	BB         indicator.BollingerBands
+
+	DEMA      float64
+	LowerBand float64
+	UpperBand float64
+
+	ADXVal    float64
+	ADXStrong bool
+
+	CurrentVolume   float64
+	AvgVolume       float64
+	VolumeConfirmed bool
+
+	ATRVal float64
+}
+
+// computeEntrySignals derives every indicator needed for an entry decision
+// from raw OHLCV data. Disabled indicators (period <= 0) or indicators
+// without enough data keep permissive semantics: ADXStrong and
+// VolumeConfirmed default to true, matching the historical live-loop
+// behavior.
+func computeEntrySignals(ohlcv *exchange.OHLCV, cfg *config.Config, tendency string) (*entrySignals, error) {
+	if ohlcv == nil || len(ohlcv.Closes) < 2 {
+		return nil, fmt.Errorf("entry signals: need at least 2 closes")
+	}
+	closes := ohlcv.Closes
+
+	rsi := indicator.CalculateSmoothedRSI(closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
+	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
+	if len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 {
+		return nil, fmt.Errorf("entry signals: insufficient candles for RSI/MACD")
+	}
+	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
+	if err != nil {
+		return nil, fmt.Errorf("BollingerBands: %w", err)
+	}
+	if len(bb.LowerBand) == 0 || len(bb.UpperBand) == 0 {
+		return nil, fmt.Errorf("entry signals: empty Bollinger bands")
+	}
+	dema := indicator.CalculateDEMA(closes, cfg.Indicators.Dema.Length)
+	if len(dema) == 0 {
+		return nil, fmt.Errorf("entry signals: empty DEMA")
+	}
+
+	sig := &entrySignals{
+		Price:      closes[len(closes)-1],
+		PrevPrice:  closes[len(closes)-2],
+		Tendency:   tendency,
+		RSI:        rsi,
+		MACDLine:   macdLine,
+		SignalLine: signalLine,
+		BB:         bb,
+		DEMA:       dema[len(dema)-1],
+		LowerBand:  bb.LowerBand[len(bb.LowerBand)-1],
+		UpperBand:  bb.UpperBand[len(bb.UpperBand)-1],
+	}
+
+	sig.ADXStrong = true
+	if cfg.Indicators.Adx.Period > 0 {
+		adx := indicator.CalculateADX(ohlcv.Highs, ohlcv.Lows, closes, cfg.Indicators.Adx.Period)
+		if len(adx) > 0 {
+			sig.ADXVal = adx[len(adx)-1]
+			sig.ADXStrong = sig.ADXVal > float64(cfg.Indicators.Adx.Threshold)
+		}
+	}
+
+	sig.VolumeConfirmed = true
+	if cfg.Indicators.Volume.MaPeriod > 0 && len(ohlcv.Volumes) > 0 {
+		volumeMA := indicator.CalculateSMA(ohlcv.Volumes, cfg.Indicators.Volume.MaPeriod)
+		sig.CurrentVolume = ohlcv.Volumes[len(ohlcv.Volumes)-1]
+		if len(volumeMA) > 0 {
+			sig.AvgVolume = volumeMA[len(volumeMA)-1]
+			sig.VolumeConfirmed = sig.CurrentVolume > sig.AvgVolume
+		}
+	}
+
+	if cfg.Indicators.Atr.Period > 0 {
+		atr := indicator.CalculateATR(ohlcv.Highs, ohlcv.Lows, closes, cfg.Indicators.Atr.Period)
+		if len(atr) > 0 {
+			sig.ATRVal = atr[len(atr)-1]
+		}
+	}
+	return sig, nil
+}
+
+// computeEntrySignalsAt computes entry signals on the candle window [0, i].
+// Backtests use this to replay decisions bar by bar on the same code path
+// as live trading.
+func computeEntrySignalsAt(ohlcv *exchange.OHLCV, i int, cfg *config.Config, tendency string) (*entrySignals, error) {
+	if ohlcv == nil || i < 1 || i >= len(ohlcv.Closes) {
+		return nil, fmt.Errorf("entry signals: index %d out of range", i)
+	}
+	window := &exchange.OHLCV{
+		Opens:   sliceTo(ohlcv.Opens, i),
+		Highs:   sliceTo(ohlcv.Highs, i),
+		Lows:    sliceTo(ohlcv.Lows, i),
+		Closes:  sliceTo(ohlcv.Closes, i),
+		Volumes: sliceTo(ohlcv.Volumes, i),
+	}
+	return computeEntrySignals(window, cfg, tendency)
+}
+
+func sliceTo(s []float64, i int) []float64 {
+	if i+1 > len(s) {
+		return s
+	}
+	return s[:i+1]
+}
+
+// evaluateClassicEntry applies the classic all-conditions-must-hold entry
+// rules for either direction and returns the per-condition breakdown for
+// logging. AI approval is layered on top by the caller.
+func evaluateClassicEntry(sig *entrySignals, cfg *config.Config, isBull bool) (bool, []entryCondition) {
+	lastRSI := sig.RSI[len(sig.RSI)-1]
+	lastMACD := sig.MACDLine[len(sig.MACDLine)-1]
+	lastSignal := sig.SignalLine[len(sig.SignalLine)-1]
+	prevMACD := sig.MACDLine[len(sig.MACDLine)-2]
+	prevSignal := sig.SignalLine[len(sig.SignalLine)-2]
+	distanceToUpper := math.Abs(sig.DEMA - sig.UpperBand)
+	distanceToLower := math.Abs(sig.DEMA - sig.LowerBand)
+
+	var rsiOk, macdCrossOk, tendOk, bbOk bool
+	var conditions []entryCondition
+	if isBull {
+		rsiOk = lastRSI < float64(cfg.Indicators.Rsi.LowerLimit)
+		macdCrossOk = prevMACD <= prevSignal && lastMACD > lastSignal
+		tendOk = sig.Tendency == "up"
+		bbOk = distanceToLower < distanceToUpper
+		conditions = []entryCondition{
+			{Name: fmt.Sprintf("RSI %.1f < %d", lastRSI, cfg.Indicators.Rsi.LowerLimit), Met: rsiOk},
+			{Name: fmt.Sprintf("MACD bullish crossover (%.6f > %.6f)", lastMACD, lastSignal), Met: macdCrossOk},
+			{Name: fmt.Sprintf("Tendency %s = up", sig.Tendency), Met: tendOk},
+			{Name: fmt.Sprintf("Closer to lower BB (lower=%.4f, upper=%.4f)", distanceToLower, distanceToUpper), Met: bbOk},
+			{Name: fmt.Sprintf("ADX strong (%.1f > %d)", sig.ADXVal, cfg.Indicators.Adx.Threshold), Met: sig.ADXStrong},
+			{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", sig.CurrentVolume, sig.AvgVolume), Met: sig.VolumeConfirmed},
+		}
+	} else {
+		rsiOk = lastRSI > float64(cfg.Indicators.Rsi.UpperLimit)
+		macdCrossOk = prevMACD >= prevSignal && lastMACD < lastSignal
+		tendOk = sig.Tendency == "down"
+		bbOk = distanceToUpper < distanceToLower
+		conditions = []entryCondition{
+			{Name: fmt.Sprintf("RSI %.1f > %d", lastRSI, cfg.Indicators.Rsi.UpperLimit), Met: rsiOk},
+			{Name: fmt.Sprintf("MACD bearish crossover (%.6f < %.6f)", lastMACD, lastSignal), Met: macdCrossOk},
+			{Name: fmt.Sprintf("Tendency %s = down", sig.Tendency), Met: tendOk},
+			{Name: fmt.Sprintf("Closer to upper BB (upper=%.4f, lower=%.4f)", distanceToUpper, distanceToLower), Met: bbOk},
+			{Name: fmt.Sprintf("ADX strong (%.1f > %d)", sig.ADXVal, cfg.Indicators.Adx.Threshold), Met: sig.ADXStrong},
+			{Name: fmt.Sprintf("Volume confirmed (%.0f > avg %.0f)", sig.CurrentVolume, sig.AvgVolume), Met: sig.VolumeConfirmed},
+		}
+	}
+	met := rsiOk && macdCrossOk && tendOk && bbOk && sig.ADXStrong && sig.VolumeConfirmed
+	return met, conditions
+}
+
+// scalpInputFromSignals adapts the shared signals to the scalp evaluator.
+func scalpInputFromSignals(sig *entrySignals, cfg *config.Config, isBull bool, closes []float64) scalpEvalInput {
+	return scalpEvalInput{
+		IsBull: isBull, Cfg: cfg,
+		Closes: closes, RSI: sig.RSI,
+		MACDLine: sig.MACDLine, SignalLine: sig.SignalLine,
+		BB: sig.BB, Tendency: sig.Tendency,
+		ADXStrong: sig.ADXStrong, ADXVal: sig.ADXVal,
+		CurrentVolume: sig.CurrentVolume, AvgVolume: sig.AvgVolume,
+		ATRVal: sig.ATRVal, Price: sig.Price,
+	}
+}
+
+// macdCrossLabel renders the MACD cross state for the TUI panel, keeping the
+// per-direction display convention used by the trade loops: the label flips
+// only on an actual crossover in the trade direction.
+func macdCrossLabel(sig *entrySignals, isBull bool) string {
+	lastMACD := sig.MACDLine[len(sig.MACDLine)-1]
+	lastSignal := sig.SignalLine[len(sig.SignalLine)-1]
+	prevMACD := sig.MACDLine[len(sig.MACDLine)-2]
+	prevSignal := sig.SignalLine[len(sig.SignalLine)-2]
+	if isBull {
+		if prevMACD <= prevSignal && lastMACD > lastSignal {
+			return "BULLISH"
+		}
+		return "BEARISH"
+	}
+	if prevMACD >= prevSignal && lastMACD < lastSignal {
+		return "BEARISH"
+	}
+	return "BULLISH"
+}

--- a/strategy/entry_rules_test.go
+++ b/strategy/entry_rules_test.go
@@ -1,0 +1,207 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/wferreirauy/binance-bot/config"
+	"github.com/wferreirauy/binance-bot/exchange"
+)
+
+// testConfig returns a minimal config with the default indicator thresholds
+// used across the entry-rule tests.
+func testConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Indicators.Rsi.UpperLimit = 70
+	cfg.Indicators.Rsi.LowerLimit = 30
+	cfg.Indicators.Rsi.Length = 14
+	cfg.Indicators.Macd.FastLength = 12
+	cfg.Indicators.Macd.SlowLength = 26
+	cfg.Indicators.Macd.SignalLength = 9
+	cfg.Indicators.BollingerBands.Length = 20
+	cfg.Indicators.BollingerBands.Multiplier = 2.0
+	cfg.Indicators.Dema.Length = 9
+	cfg.Indicators.Adx.Threshold = 25
+	return cfg
+}
+
+// bullSignals builds an entrySignals snapshot where every classic bull
+// condition holds: RSI oversold, fresh MACD bullish crossover, tendency up,
+// DEMA nearer the lower band, strong ADX and confirmed volume.
+func bullSignals() *entrySignals {
+	return &entrySignals{
+		Price:    100,
+		Tendency: "up",
+		RSI:      []float64{35, 28},
+		// prev: macd <= signal, last: macd > signal → bullish crossover
+		MACDLine:        []float64{-0.5, 0.2},
+		SignalLine:      []float64{-0.3, 0.1},
+		DEMA:            101,
+		LowerBand:       99,
+		UpperBand:       110,
+		ADXVal:          30,
+		ADXStrong:       true,
+		CurrentVolume:   1500,
+		AvgVolume:       1000,
+		VolumeConfirmed: true,
+	}
+}
+
+// bearSignals mirrors bullSignals for the bear direction.
+func bearSignals() *entrySignals {
+	return &entrySignals{
+		Price:    100,
+		Tendency: "down",
+		RSI:      []float64{65, 75},
+		// prev: macd >= signal, last: macd < signal → bearish crossover
+		MACDLine:        []float64{0.5, -0.2},
+		SignalLine:      []float64{0.3, -0.1},
+		DEMA:            109,
+		LowerBand:       90,
+		UpperBand:       110,
+		ADXVal:          30,
+		ADXStrong:       true,
+		CurrentVolume:   1500,
+		AvgVolume:       1000,
+		VolumeConfirmed: true,
+	}
+}
+
+func TestClassicBullEntryAllConditionsMet(t *testing.T) {
+	met, conditions := evaluateClassicEntry(bullSignals(), testConfig(), true)
+	if !met {
+		t.Fatalf("expected bull entry, conditions: %+v", conditions)
+	}
+	if len(conditions) != 6 {
+		t.Fatalf("expected 6 condition entries, got %d", len(conditions))
+	}
+}
+
+func TestClassicBearEntryAllConditionsMet(t *testing.T) {
+	met, conditions := evaluateClassicEntry(bearSignals(), testConfig(), false)
+	if !met {
+		t.Fatalf("expected bear entry, conditions: %+v", conditions)
+	}
+}
+
+func TestClassicEntryBlockedByWeakADX(t *testing.T) {
+	sig := bullSignals()
+	sig.ADXStrong = false
+	if met, _ := evaluateClassicEntry(sig, testConfig(), true); met {
+		t.Fatal("weak ADX must block classic entry")
+	}
+}
+
+func TestClassicEntryBlockedByUnconfirmedVolume(t *testing.T) {
+	sig := bullSignals()
+	sig.VolumeConfirmed = false
+	if met, _ := evaluateClassicEntry(sig, testConfig(), true); met {
+		t.Fatal("unconfirmed volume must block classic entry")
+	}
+}
+
+func TestClassicEntryBlockedByTendencyMismatch(t *testing.T) {
+	sig := bullSignals()
+	sig.Tendency = "down"
+	if met, _ := evaluateClassicEntry(sig, testConfig(), true); met {
+		t.Fatal("bull entry requires up tendency")
+	}
+}
+
+func TestClassicEntryBlockedWithoutMACDCross(t *testing.T) {
+	sig := bullSignals()
+	// already above signal on both bars → no fresh crossover
+	sig.MACDLine = []float64{0.3, 0.4}
+	sig.SignalLine = []float64{0.1, 0.1}
+	if met, _ := evaluateClassicEntry(sig, testConfig(), true); met {
+		t.Fatal("no fresh MACD crossover must block classic entry")
+	}
+}
+
+func TestComputeEntrySignalsPermissiveDefaults(t *testing.T) {
+	cfg := testConfig()
+	// ADX and volume disabled (Period/MaPeriod = 0) → permissive gates.
+	n := 60
+	ohlcv := &exchange.OHLCV{}
+	for i := 0; i < n; i++ {
+		price := 100 + float64(i%7)
+		ohlcv.Opens = append(ohlcv.Opens, price)
+		ohlcv.Highs = append(ohlcv.Highs, price+1)
+		ohlcv.Lows = append(ohlcv.Lows, price-1)
+		ohlcv.Closes = append(ohlcv.Closes, price)
+		ohlcv.Volumes = append(ohlcv.Volumes, 1000)
+	}
+	sig, err := computeEntrySignals(ohlcv, cfg, "up")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sig.ADXStrong {
+		t.Fatal("disabled ADX must default to strong")
+	}
+	if !sig.VolumeConfirmed {
+		t.Fatal("disabled volume MA must default to confirmed")
+	}
+	if sig.Price != ohlcv.Closes[n-1] {
+		t.Fatalf("price mismatch: %v != %v", sig.Price, ohlcv.Closes[n-1])
+	}
+}
+
+func TestComputeEntrySignalsEnforcesADXWhenConfigured(t *testing.T) {
+	cfg := testConfig()
+	cfg.Indicators.Adx.Period = 14
+	cfg.Indicators.Adx.Threshold = 99 // impossible bar for flat series
+	n := 60
+	ohlcv := &exchange.OHLCV{}
+	for i := 0; i < n; i++ {
+		price := 100 + float64(i%3)
+		ohlcv.Opens = append(ohlcv.Opens, price)
+		ohlcv.Highs = append(ohlcv.Highs, price+0.5)
+		ohlcv.Lows = append(ohlcv.Lows, price-0.5)
+		ohlcv.Closes = append(ohlcv.Closes, price)
+		ohlcv.Volumes = append(ohlcv.Volumes, 1000)
+	}
+	sig, err := computeEntrySignals(ohlcv, cfg, "up")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sig.ADXStrong {
+		t.Fatal("flat market cannot beat ADX threshold 99; gate must hold")
+	}
+}
+
+func TestComputeEntrySignalsRejectsShortSeries(t *testing.T) {
+	ohlcv := &exchange.OHLCV{Closes: []float64{100}}
+	if _, err := computeEntrySignals(ohlcv, testConfig(), "up"); err == nil {
+		t.Fatal("expected error for insufficient candles")
+	}
+}
+
+func TestComputeEntrySignalsAtMatchesWindow(t *testing.T) {
+	cfg := testConfig()
+	n := 80
+	full := &exchange.OHLCV{}
+	for i := 0; i < n; i++ {
+		price := 100 + float64(i)*0.1
+		full.Opens = append(full.Opens, price)
+		full.Highs = append(full.Highs, price+1)
+		full.Lows = append(full.Lows, price-1)
+		full.Closes = append(full.Closes, price)
+		full.Volumes = append(full.Volumes, 1000+float64(i))
+	}
+	at := 50
+	sigAt, err := computeEntrySignalsAt(full, at, cfg, "up")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	window := &exchange.OHLCV{
+		Opens: full.Opens[:at+1], Highs: full.Highs[:at+1], Lows: full.Lows[:at+1],
+		Closes: full.Closes[:at+1], Volumes: full.Volumes[:at+1],
+	}
+	sigWin, err := computeEntrySignals(window, cfg, "up")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sigAt.Price != sigWin.Price || sigAt.DEMA != sigWin.DEMA ||
+		sigAt.RSI[len(sigAt.RSI)-1] != sigWin.RSI[len(sigWin.RSI)-1] {
+		t.Fatal("windowed computation must match direct computation on the same slice")
+	}
+}

--- a/strategy/registry.go
+++ b/strategy/registry.go
@@ -2,12 +2,10 @@ package strategy
 
 import (
 	"fmt"
-	"math"
 	"sort"
 
 	"github.com/wferreirauy/binance-bot/config"
 	"github.com/wferreirauy/binance-bot/exchange"
-	"github.com/wferreirauy/binance-bot/indicator"
 )
 
 type Signal string
@@ -67,32 +65,19 @@ func (classicBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 	if i < 2 || i >= len(ohlcv.Closes) {
 		return SignalHold
 	}
-	closes := ohlcv.Closes[:i+1]
-	dema := indicator.CalculateDEMA(closes, cfg.Indicators.Dema.Length)
-	rsi := indicator.CalculateRSI(closes, cfg.Indicators.Rsi.Length)
-	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
-	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
-	if err != nil || len(dema) == 0 || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
-		return SignalHold
-	}
-	price := closes[len(closes)-1]
+	price := ohlcv.Closes[i]
 	if snapshot.Position {
 		if price <= snapshot.EntryPrice*(1-snapshot.Config.Backtest.FeePct/100) {
 			return SignalHold
 		}
 		return SignalSell
 	}
-	currentDema := dema[len(dema)-1]
-	lowerBand := bb.LowerBand[len(bb.LowerBand)-1]
-	upperBand := bb.UpperBand[len(bb.UpperBand)-1]
-	distanceToUpper := math.Abs(currentDema - upperBand)
-	distanceToLower := math.Abs(currentDema - lowerBand)
-	macdCrossOk := macdLine[len(macdLine)-2] <= signalLine[len(signalLine)-2] &&
-		macdLine[len(macdLine)-1] > signalLine[len(signalLine)-1]
-	if rsi[len(rsi)-1] < float64(cfg.Indicators.Rsi.LowerLimit) &&
-		macdCrossOk &&
-		snapshot.Tendency == "up" &&
-		distanceToLower < distanceToUpper {
+	// Same decision path as the live loops: shared signals + shared rules.
+	sig, err := computeEntrySignalsAt(ohlcv, i, cfg, snapshot.Tendency)
+	if err != nil {
+		return SignalHold
+	}
+	if met, _ := evaluateClassicEntry(sig, cfg, true); met {
 		return SignalBuy
 	}
 	return SignalHold
@@ -116,28 +101,13 @@ func (scalpBullStrategy) Decide(snapshot MarketSnapshot) Signal {
 		}
 		return SignalHold
 	}
-	closes := ohlcv.Closes[:i+1]
-	rsi := indicator.CalculateSmoothedRSI(closes, cfg.Indicators.Rsi.Length, cfg.Indicators.Rsi.SmoothLength)
-	macdLine, signalLine := indicator.CalculateMACD(closes, cfg.Indicators.Macd.FastLength, cfg.Indicators.Macd.SlowLength, cfg.Indicators.Macd.SignalLength)
-	bb, err := indicator.CalculateBollingerBands(closes, cfg.Indicators.BollingerBands.Length, cfg.Indicators.BollingerBands.Multiplier)
-	if err != nil || len(rsi) == 0 || len(macdLine) < 2 || len(signalLine) < 2 || len(bb.LowerBand) == 0 {
+	// Same decision path as the live loops: shared signals feed the scalp
+	// evaluator, so backtests honor ADX/volume exactly like live trading.
+	sig, err := computeEntrySignalsAt(ohlcv, i, cfg, snapshot.Tendency)
+	if err != nil {
 		return SignalHold
 	}
-	var atrVal float64
-	if cfg.Indicators.Atr.Period > 0 {
-		atr := indicator.CalculateATR(ohlcv.Highs[:i+1], ohlcv.Lows[:i+1], closes, cfg.Indicators.Atr.Period)
-		if len(atr) > 0 {
-			atrVal = atr[len(atr)-1]
-		}
-	}
-	eval := evaluateScalp(scalpEvalInput{
-		IsBull: true, Cfg: cfg,
-		Closes: closes, RSI: rsi,
-		MACDLine: macdLine, SignalLine: signalLine,
-		BB: bb, Tendency: snapshot.Tendency,
-		ADXStrong: true, // ADX is permissive in the registry/backtest strategy
-		ATRVal:    atrVal, Price: price,
-	})
+	eval := evaluateScalp(scalpInputFromSignals(sig, cfg, true, ohlcv.Closes[:i+1]))
 	if eval.RegimeBlocked || eval.ExtremeBlocked {
 		return SignalHold
 	}


### PR DESCRIPTION
# fix(strategy): unify live/backtest entry decision path (v0.14.3)

## Summary

Entry decisions were previously implemented five times: inline in `bull.go`, `bear.go`, twice in `dynamic.go` (bull/bear branches), and once more in `registry.go` for backtests. The backtest copies had silently diverged from live trading:

- `classic-bull` used **raw RSI** (ignoring `indicators.rsi.smooth-length`) and skipped the **ADX** and **volume** gates entirely.
- `scalp-bull` hardcoded `ADXStrong: true` and never computed volume, so ADX/volume-based scoring behaved differently than live.

This meant backtest results were not representative of live entry behavior for the same config — a correctness bug for a trading bot.

## Changes

- **New `strategy/entry_rules.go`** — single source of truth for entry decisions:
  - `entrySignals` + `computeEntrySignals` / `computeEntrySignalsAt`: one shared indicator-snapshot computation (RSI incl. smoothing, MACD, Bollinger, DEMA, ADX, volume, ATR) with the live loops' permissive defaults for disabled indicators.
  - `evaluateClassicEntry`: the classic all-conditions entry rule for both directions, returning the per-condition breakdown used by the TUI activity log.
  - `scalpInputFromSignals` and `macdCrossLabel` adapters.
- **`bull.go` / `bear.go` / `dynamic.go`** — inline indicator computation and classic entry conditions replaced by the shared evaluators (~230 duplicated lines removed). No trade-behavior change intended for live loops; the only functional difference is that an invalid Bollinger computation now safely skips the scan iteration instead of risking an index panic on empty bands.
- **`registry.go`** — `classic-bull` and `scalp-bull` now decide through the shared path, so backtests honor smoothed RSI, ADX, and volume exactly as configured.
- **New `strategy/entry_rules_test.go`** — first tests for the `strategy` package: classic bull/bear entry acceptance, ADX/volume/tendency/MACD-cross blocking, permissive defaults for disabled indicators, ADX enforcement, and windowed-vs-direct signal equivalence.
- **Docs** — README features list and backtest section updated; version bumped to `v0.14.3`.

## Behavior impact

- **Live trading (`bull-trade`, `bear-trade`, `auto-trade`)**: unchanged entry semantics.
- **Backtest (`backtest`)**: entries now respect `indicators.rsi.smooth-length`, the ADX threshold, and volume confirmation. Backtest results may differ from previous versions — they are now correct.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass, including 10 new `strategy` tests